### PR TITLE
Add script to generate tables; add data in yml; add more features

### DIFF
--- a/Fodderator.js
+++ b/Fodderator.js
@@ -10,6 +10,7 @@
 
 var Fodder = Fodder || {
     version: "0.0.3",
+    sheetVersion: "1.5.1", // DCC_Tabbed_Sheet version
     defaultAvatar: "https://s3.amazonaws.com/files.d20.io/images/7165064/VtQt1TimmSc8rxdHH4daxg/med.jpg?1421350799",
     output: [],
 
@@ -308,7 +309,10 @@ var Fodder = Fodder || {
     },
 
     save: function() {
-      var attr;
+      const workerOptions = ["current", "max"];
+      let createObjWithWorker = function(type, options) {
+        return createObj(type, _.omit(options, workerOptions)).setWithWorker(_.pick(options, workerOptions));
+      };
       var character = createObj("character", {
           avatar: Fodder.defaultAvatar,
           name: Fodder.name,
@@ -319,233 +323,237 @@ var Fodder = Fodder || {
           controlledby: Fodder.id
       });
 
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'player_name',
           current: Fodder.player,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'Name',
           current: Fodder.name,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'Languages',
           current: 'Common',
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'Speed',
           current: 30,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'Level',
           current: '0',
           max: '10',
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'XP',
           current: 0,
           max: 10,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'str',
           current: Fodder.strength,
           max: Fodder.strength,
-          _characterid: character.id
+          characterid: character.id
       });
-      attr = createObj('attribute', {
+      createObjWithWorker('attribute', {
         name: 'agi',
+        current: Fodder.agility,
+        max: Fodder.agility,
         characterid: character.id
       });
-      attr.setWithWorker({
-        current: Fodder.agility,
-        max: Fodder.agility
-      });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'sta',
           current: Fodder.stamina,
           max: Fodder.stamina,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'per',
           current: Fodder.personality,
           max: Fodder.personality,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'int',
           current: Fodder.intelligence,
           max: Fodder.intelligence,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'luck',
           current: Fodder.luck,
           max: Fodder.luck,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'strMax',
           current: Fodder.strength,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'agiMax',
           current: Fodder.agility,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'staMax',
           current: Fodder.stamina,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'perMax',
           current: Fodder.personality,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'intMax',
           current: Fodder.intelligence,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'luckMax',
           current: Fodder.luck,
-          _characterid: character.id
+          characterid: character.id
       });
-      attr = createObj('attribute', {
+      createObjWithWorker('attribute', {
         name: 'luckStarting',
-        _characterid: character.id
-      });
-      attr.setWithWorker({
         current: Fodder.luck,
-        max: Fodder.luck
+        max: Fodder.luck,
+        characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'HP',
           current: Fodder.hp,
           max: Fodder.hp,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'CP',
           current: Fodder.cp,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'BirthAugur',
           current: Fodder.luckyRoll.birthAugur,
-          _characterid: character.id
+          characterid: character.id
       });
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'LuckyRoll',
           current: Fodder.luckyRoll.detail,
-          _characterid: character.id
+          characterid: character.id
       });
       if (Fodder.luckyRoll.attr && Fodder.luckyRoll.attr.indexOf("special") === -1) {
-        attr = createObj('attribute', {
+        createObjWithWorker('attribute', {
           name: Fodder.luckyRoll.attr,
-          characterid: character.id
-        });
-        attr.setWithWorker({
           current: Fodder.luckyRoll.attr === 'armorClassLuckyRoll' ? "on" : "[[@{luckStartingMod}]]",
+          characterid: character.id
         });
       }
       if (typeof Fodder.race != "undefined") {
-        createObj('attribute', {
+        createObjWithWorker('attribute', {
             name: 'Race',
             current: Fodder.race,
-            _characterid: character.id
+            characterid: character.id
         });
       }
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'Occupation',
           current: Fodder.occupation,
-          _characterid: character.id
+          characterid: character.id
       });
       if (Fodder.weapon.attackType === 'melee' || Fodder.weapon.attackType === 'both') {
           const rowId = Fodder.generateRowID();
           const prefix = `repeating_meleeweapon_${rowId}`;
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_meleeWeaponName`,
               current: Fodder.weapon.name,
-              _characterid: character.id
+              characterid: character.id
           });
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_meleeDmg`,
               current: Fodder.weapon.damage,
-              _characterid: character.id
+              characterid: character.id
           });
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_meleeAttackWielded`,
               current: Fodder.weapon.handedness,
-              _characterid: character.id
+              characterid: character.id
           });
           if (Fodder.luckyRoll.attr === "special_zeroWeaponLuckyRoll") {
-            createObj('attribute', {
+            createObjWithWorker('attribute', {
                 name: `${prefix}_zeroWeaponLuckyRoll`,
                 current: "@{luckStartingMod}",
-                _characterid: character.id
+                characterid: character.id
             });
           }
       }
       if (Fodder.weapon.attackType === 'ranged' || Fodder.weapon.attackType === 'both') {
           const rowId = Fodder.generateRowID();
           const prefix = `repeating_rangedweapon_${rowId}`;
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_rangedAmmo`,
               current: Fodder.weapon.ammo,
-              _characterid: character.id
+              characterid: character.id
           });
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_rangedWeaponName`,
               current: Fodder.weapon.name,
-              _characterid: character.id
+              characterid: character.id
           });
           const [distShort, distMed, distLong] = Fodder.weapon.rangedDistance.split('/');
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_rangedDistanceShort`,
               current: distShort,
-              _characterid: character.id
+              characterid: character.id
           });
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_rangedDistanceMed`,
               current: distMed,
-              _characterid: character.id
+              characterid: character.id
           });
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_rangedDistanceLong`,
               current: distLong,
-              _characterid: character.id
+              characterid: character.id
           });
-          createObj('attribute', {
-              name: `${prefix}_rangedWeaponType`,
-              current: Fodder.weapon.rangedType,
-              _characterid: character.id
-          });
-          createObj('attribute', {
+          createObjWithWorker('attribute', {
               name: `${prefix}_rangedDmg`,
               current: Fodder.weapon.damage,
-              _characterid: character.id
+              characterid: character.id
           });
           if (Fodder.luckyRoll.attr === "special_zeroWeaponLuckyRoll") {
-            createObj('attribute', {
+            createObjWithWorker('attribute', {
                 name: `${prefix}_zeroRangedWeaponLuckyRoll`,
                 current: "@{luckStartingMod}",
-                _characterid: character.id
+                characterid: character.id
             });
           }
+          createObjWithWorker('attribute', {
+            name: `${prefix}_rangedAttackDice`,
+            current: "d20",
+            characterid: character.id
+          });
+          createObjWithWorker('attribute', {
+            name: `${prefix}_rangedWeaponType`,
+            current: Fodder.weapon.rangedType,
+            characterid: character.id
+          });
       }
-      createObj('attribute', {
+      createObjWithWorker('attribute', {
           name: 'Equipment',
           current: Fodder.trade + "\n" + Fodder.equipment,
-          _characterid: character.id
+          characterid: character.id
+      });
+      createObjWithWorker('attribute', {
+          name: '_charsheetVersion',
+          current: Fodder.sheetVersion,
+          characterid: character.id
       });
     },
 

--- a/Fodderator.js
+++ b/Fodderator.js
@@ -25,7 +25,7 @@ var Fodder = Fodder || {
                     Fodder.showHelp();
                 } else {
                     Fodder.setTables(input[1]);
-                    sendChat('API', "/direct <h6>Generating character</h6>");
+                    sendChat('API', "/direct <h6>Generating character</h6> (please do not generate another until this one is done!)");
                     Fodder.generate(msg, Fodder.printSheet, Fodder.save);
                 }
             } else if (msg.content.indexOf("!fodder") != -1) {

--- a/Fodderator.js
+++ b/Fodderator.js
@@ -77,7 +77,6 @@ var Fodder = Fodder || {
         Fodder.id = msg.playerid;
         Fodder.player = msg.who;
         Fodder.name = msg.who + " #" + (findObjs({_type: "character", controlledby: msg.playerid}).length + 1)
-        Fodder.gender = Fodder.rollGender();
         Fodder.strength = Fodder.rollAbility();
         Fodder.strengthMod = Fodder.calcMod(Fodder.strength);
         Fodder.agility = Fodder.rollAbility();
@@ -108,16 +107,6 @@ var Fodder = Fodder || {
         if (typeof outputCallback === "function") {
           setTimeout(outputCallback, 2500, msg, saveCallback);
         }
-    },
-
-    /* Should account for more than male and female? */
-    rollGender: function () {
-      var coinFlip = randomInteger(100);
-      if (coinFlip <= 50) {
-        return "Male";
-      } else {
-        return "Female";
-      }
     },
 
     rollAbility: function () {
@@ -208,7 +197,6 @@ var Fodder = Fodder || {
       var styleLabel = "style='font-weight: bold; padding: 5px;'";
       var styleVal = "style='padding: 5px;'";
       Fodder.output['name'] = "<thead><tr><th colspan='2' style='background: #8C8173; padding: 5px;'>" + Fodder.name + "</th></tr></thead>";
-      Fodder.output['gender'] = "<tr><td " + styleLabel + ">Gender</td><td " + styleVal + ">" + Fodder.gender + "</td></tr>";
       if (Fodder.race != undefined) {
         Fodder.output['race'] = "<tr><td " + styleLabel + ">Race</td><td " + styleVal + ">" + Fodder.race + "</td></tr>";
       } else {
@@ -255,7 +243,6 @@ var Fodder = Fodder || {
 
       sendChat(msg.who, "/direct <table style='background: #DCD9D5; border-radius: 20px; font-size: 10px;'>" + Fodder.output['name'] +
           "<tbody>" +
-          Fodder.output['gender'] +
           Fodder.output['race'] +
           Fodder.output['occupation'] +
           Fodder.output['abilities'] +
@@ -291,11 +278,6 @@ var Fodder = Fodder || {
       createObj('attribute', {
           name: 'Name',
           current: Fodder.name,
-          _characterid: character.id
-      });
-      createObj('attribute', {
-          name: 'gender',
-          current: Fodder.gender,
           _characterid: character.id
       });
       createObj('attribute', {

--- a/Fodderator.js
+++ b/Fodderator.js
@@ -260,6 +260,7 @@ var Fodder = Fodder || {
     },
 
     save: function() {
+      var attr;
       var character = createObj("character", {
           avatar: Fodder.defaultAvatar,
           name: Fodder.name,
@@ -308,11 +309,13 @@ var Fodder = Fodder || {
           max: Fodder.strength,
           _characterid: character.id
       });
-      createObj('attribute', {
-          name: 'agi',
-          current: Fodder.agility,
-          max: Fodder.agility,
-          _characterid: character.id
+      attr = createObj('attribute', {
+        name: 'agi',
+        characterid: character.id
+      });
+      attr.setWithWorker({
+        current: Fodder.agility,
+        max: Fodder.agility
       });
       createObj('attribute', {
           name: 'sta',
@@ -368,11 +371,13 @@ var Fodder = Fodder || {
           current: Fodder.luck,
           _characterid: character.id
       });
-      createObj('attribute', {
-          name: 'luckStarting',
-          current: Fodder.luck,
-          max: Fodder.luck,
-          _characterid: character.id
+      attr = createObj('attribute', {
+        name: 'luckStarting',
+        _characterid: character.id
+      });
+      attr.setWithWorker({
+        current: Fodder.luck,
+        max: Fodder.luck
       });
       createObj('attribute', {
           name: 'HP',
@@ -395,11 +400,13 @@ var Fodder = Fodder || {
           current: Fodder.luckyRoll.detail,
           _characterid: character.id
       });
-      if (Fodder.luckyRoll.attr && Fodder.luckyRoll.attr.indexOf("special") == -1) {
-        createObj('attribute', {
-            name: Fodder.luckyRoll.attr,
-            current: "[[@{luckStartingMod}]]",
-            _characterid: character.id
+      if (Fodder.luckyRoll.attr && Fodder.luckyRoll.attr.indexOf("special") === -1) {
+        attr = createObj('attribute', {
+          name: Fodder.luckyRoll.attr,
+          characterid: character.id
+        });
+        attr.setWithWorker({
+          current: Fodder.luckyRoll.attr === 'armorClassLuckyRoll' ? "on" : "[[@{luckStartingMod}]]",
         });
       }
       if (typeof Fodder.race != "undefined") {

--- a/data/birth_augur.yml
+++ b/data/birth_augur.yml
@@ -1,0 +1,91 @@
+Birth-Augur-Lucky-Roll-Core:
+- birth_augur: Harsh winter
+  lucky_roll: All attack rolls
+  attr: allAtkLuckyRoll
+- birth_augur: The Bull
+  lucky_roll: Melee attack rolls
+  attr: meleeAtkLuckyRoll
+- birth_augur: Fortunate Date
+  lucky_roll: Missile fire attack rolls
+  attr: rangedAtkLuckyRoll
+- birth_augur: Raised by wolves
+  lucky_roll: Unarmed attack rolls
+  attr: # TODO
+- birth_augur: Conceived on horseback
+  lucky_roll: Mounted attack rolls
+  attr: # TODO
+- birth_augur: Born on the battlefield
+  lucky_roll: Damage rolls
+  attr: dmgLuckyRoll
+- birth_augur: Path of the bear
+  lucky_roll: Melee damage rolls
+  attr: meleeDmgLuckyRoll
+- birth_augur: Hawkeye
+  lucky_roll: Missile fire damage rolls
+  attr: rangedDmgLuckyRoll
+- birth_augur: Pack hunter
+  lucky_roll: Attack and damage rolls for 0-level starting weapon
+  attr: special_zeroWeaponLuckyRoll
+- birth_augur: Born under the loom
+  lucky_roll: Skill checks (including thief skills)
+  attr: skillChecksLuckyRoll
+- birth_augur: Fox's cunning
+  lucky_roll: Find / disable traps
+  attr: findDisableTrapsLuckyRoll
+- birth_augur: Four-leafed clover
+  lucky_roll: Find secret doors
+  attr: findSecretDoorsLuckyRoll
+- birth_augur: Seventh son
+  lucky_roll: Spell checks
+  attr: spellCastLuckyRoll
+- birth_augur: The raging storm
+  lucky_roll: Spell damage
+  attr: # TODO
+- birth_augur: Righteous heart
+  lucky_roll: Turn unholy checks
+  attr: turnUnholyLuckyRoll
+- birth_augur: Survived the plague
+  lucky_roll: Magical Healing
+  attr: layOnHandsLuckyRoll
+- birth_augur: Lucky sign
+  lucky_roll: Saving throws
+  attr: savingThrowsLuckyRoll
+- birth_augur: Guardian angel
+  lucky_roll: Saving throws to escape traps
+  attr: # TODO
+- birth_augur: Survived a spider bite
+  lucky_roll: Saving throws against poison
+  attr: # TODO
+- birth_augur: Struck by lightning
+  lucky_roll: Reflex saving throws
+  attr: reflexLuckyRoll
+- birth_augur: Lived through famine
+  lucky_roll: Fortitude saving throws
+  attr: fortitudeLuckyRoll
+- birth_augur: Resisted temptation
+  lucky_roll: Willpower saving throws
+  attr: willLuckyRoll
+- birth_augur: Charmed house
+  lucky_roll: Armor class
+  attr: armorClassLuckyRoll
+- birth_augur: Speed of the cobra
+  lucky_roll: Initiative
+  attr: initLuckyRoll
+- birth_augur: Bountiful harvest
+  lucky_roll: Hit points (applies at each level)
+  attr: hpLuckyRoll
+- birth_augur: Warrior's arm
+  lucky_roll: Critical hit tables
+  attr: critLuckyRoll
+- birth_augur: Unholy house
+  lucky_roll: Corruption rolls
+  attr: corruptionLuckyRoll
+- birth_augur: The Broken Star
+  lucky_roll: Fumbles
+  attr: fumbleLuckyRoll
+- birth_augur: Birdsong
+  lucky_roll: Number of languages
+  attr: # TODO
+- birth_augur: Wild child
+  lucky_roll: Speed (each +1 / -1 = +5' / -5' speed)
+  attr: speedLuckyRoll

--- a/data/equipment.yml
+++ b/data/equipment.yml
@@ -1,0 +1,75 @@
+Equipment-Core:
+- Backpack
+- Candle
+- Chain, 10'
+- Chalk, 1 piece
+- Chest, empty
+- Crowbar
+- Flask, empty
+- Flint & steel
+- Grappling hook
+- Hammer, small
+- Holy symbol
+- Holy water, 1 vial
+- Iron spike
+- Lantern
+- Mirror, hand-sized
+- Oil, 1 flask
+- Pole, 10'
+- Rations, 1 day
+- Rope, 50'
+- Sack, large
+- Sack, small
+- Thieves' tools
+- Torch
+- Waterskin
+Equipment-CUaBM:
+- 3 Plasticware Containers
+- 4 Firestarter Bricks
+- 20 Resealable Plastic Bags
+- Backpack
+- Big Box of Crayons
+- Bottle of Lighter Fluid
+- Camping Trowel
+- Can Opener
+- Canteen
+- Cast Iron Dutch Oven
+- Chain, 10'
+- Chalk, 1 piece
+- Chest, empty
+- Cintronella Candle
+- Cooler, 12 can size
+- Crowbar
+- Easy Reach Grabber
+- Fire Extinguisher (charged)
+- Fishing Waders
+- Gas Can (1 gallon)
+- Glowstick
+- Grappling Hook
+- Hand-Crank Flashlight
+- Holy Symbol
+- Holy Water, 1 vial
+- Insulated Thermos
+- Iron Spike
+- Kitchen Shears
+- Lantern
+- Leatherman Multi-Tool
+- Metal Tongs
+- Mirror, Hand-sized
+- Nylon Rope, 50'
+- Oil, 1 flask
+- Pocket Fisherman
+- Poker Set with Chips
+- Pole, 10'
+- Rations, per day
+- Sack, Large
+- Sack, Small
+- Small Hammer (1d3)
+- Small Socket Wrench Set
+- Solar Wristwatch
+- Thermal Sleeping Bag
+- Thieve's Tools
+- Umbrella
+- Utility Knife (1d3)
+- Water Kettle
+- Zippo Lighter with Lighter Fluid

--- a/data/farm_animals.yml
+++ b/data/farm_animals.yml
@@ -1,0 +1,11 @@
+---
+Farm-Animals-Core: &farm_animals_core
+- Hen
+- Sheep
+- Goat
+- Cow
+- Duck
+- Goose
+- Mule
+- Herding Dog
+- Sow

--- a/data/farmer.yml
+++ b/data/farmer.yml
@@ -1,0 +1,10 @@
+---
+Farmer-Core: &farmer_core
+- Potato Farmer
+- Wheat Farmer
+- Turnip Farmer
+- Corn Farmer
+- Rice Farmer
+- Parsnip Farmer
+- Radish Farmer
+- Rutabega Farmer

--- a/data/occupations.yml
+++ b/data/occupations.yml
@@ -143,8 +143,7 @@ Occupations-Core: &occupations_core
 - race: human
   occupation: "$subtable-Farmer-Core"
   starting_weapon: Pitchfork (as spear)
-  # TODO support subtables
-  trade_item: Hen
+  trade_item: "$subtable-Farm-Animals-Core"
   weight: 9
 - race: human
   occupation: Fortune-teller

--- a/data/occupations.yml
+++ b/data/occupations.yml
@@ -87,7 +87,7 @@ Occupations-Core: &occupations_core
 - race: dwarf
   occupation: Dwarven herder
   starting_weapon: Staff
-  trade_item: Sow
+  trade_item: "$subtable-Farm-Animals-Core"
 - race: dwarf
   occupation: Dwarven miner
   starting_weapon: Pick (as club)
@@ -141,7 +141,7 @@ Occupations-Core: &occupations_core
   trade_item: Parchment, quill
   weight: 2
 - race: human
-  occupation: Farmer
+  occupation: "$subtable-Farmer-Core"
   starting_weapon: Pitchfork (as spear)
   # TODO support subtables
   trade_item: Hen
@@ -216,7 +216,7 @@ Occupations-Core: &occupations_core
 - race: human
   occupation: Herder
   starting_weapon: Staff
-  trade_item: Herding dog
+  trade_item: "$subtable-Farm-Animals-Core"
 - race: human
   occupation: Hunter
   starting_weapon: Shortbow
@@ -319,7 +319,7 @@ Occupations-Core: &occupations_core
 - race: human
   occupation: Wainwright
   starting_weapon: Club
-  trade_item: Pushcart
+  trade_item: "$subtable-Pushcart-Core"
 - race: human
   occupation: Weaver
   starting_weapon: Dagger

--- a/data/occupations.yml
+++ b/data/occupations.yml
@@ -1,0 +1,442 @@
+---
+Occupations-Core: &occupations_core
+- race: human
+  occupation: Alchemist
+  starting_weapon: Staff
+  trade_item: Flask of oil
+- race: human
+  occupation: Animal trainer
+  starting_weapon: Club
+  trade_item: Pony
+- race: human
+  occupation: Armorer
+  starting_weapon: Hammer (as club)
+  trade_item: Iron helmet
+- race: human
+  occupation: Astrologer
+  starting_weapon: Dagger
+  trade_item: Spyglass
+- race: human
+  occupation: Barber
+  starting_weapon: Razor (as dagger)
+  trade_item: Scissors
+- race: human
+  occupation: Beadle
+  starting_weapon: Staff
+  trade_item: Holy symbol
+- race: human
+  occupation: Beekeeper
+  starting_weapon: Staff
+  trade_item: Jar of honey
+- race: human
+  occupation: Blacksmith
+  starting_weapon: Hammer (as club)
+  trade_item: Steel tongs
+- race: human
+  occupation: Butcher
+  starting_weapon: Cleaver (as handaxe)
+  trade_item: Side of beef
+- race: human
+  occupation: Caravan guard
+  starting_weapon: Short sword
+  trade_item: Linen (1 yard)
+- race: human
+  occupation: Cheesemaker
+  starting_weapon: Cudgel (as staff)
+  trade_item: Stinky cheese
+- race: human
+  occupation: Cobbler
+  starting_weapon: Awl (as dagger)
+  trade_item: Shoehorn
+- race: human
+  occupation: Confidence artist
+  starting_weapon: Dagger
+  trade_item: Quality cloak
+- race: human
+  occupation: Cooper
+  starting_weapon: Crowbar (as club)
+  trade_item: Barrel
+- race: human
+  occupation: Costermonger
+  starting_weapon: Knife (as dagger)
+  trade_item: Fruit
+- race: human
+  occupation: Cutpurse
+  starting_weapon: Dagger
+  trade_item: Small chest
+- race: human
+  occupation: Ditch digger
+  starting_weapon: Shovel (as staff)
+  trade_item: Fine dirt (1 lb.)
+- race: human
+  occupation: Dock worker
+  starting_weapon: Pole (as staff)
+  trade_item: 1 late RPG book
+- race: dwarf
+  occupation: Dwarven apothecarist
+  starting_weapon: Cudgel (as staff)
+  trade_item: Steel vial
+- race: dwarf
+  occupation: Dwarven blacksmith
+  starting_weapon: Hammer (as club)
+  trade_item: Mithril (1 oz.)
+- race: dwarf
+  occupation: Dwarven chest-maker
+  starting_weapon: Chisel (as dagger)
+  trade_item: Wood (10 lbs.)
+- race: dwarf
+  occupation: Dwarven herder
+  starting_weapon: Staff
+  trade_item: Sow
+- race: dwarf
+  occupation: Dwarven miner
+  starting_weapon: Pick (as club)
+  trade_item: Lantern
+  weight: 2
+- race: dwarf
+  occupation: Dwarven mushroom-farmer
+  starting_weapon: Shovel (as staff)
+  trade_item: Sack
+- race: dwarf
+  occupation: Dwarven rat-catcher
+  starting_weapon: Club
+  trade_item: Net
+- race: dwarf
+  occupation: Dwarven stonemason
+  starting_weapon: Hammer (as club)
+  trade_item: Fine stone (10 lbs.)
+  weight: 2
+- race: elf
+  occupation: Elven artisan
+  starting_weapon: Staff
+  trade_item: Clay (1 lb.)
+- race: elf
+  occupation: Elven barrister
+  starting_weapon: Quill (as dart)
+  trade_item: Book
+- race: elf
+  occupation: Elven chandler
+  starting_weapon: Scissors (as dagger)
+  trade_item: Candles (20)
+- race: elf
+  occupation: Elven falconer
+  starting_weapon: Dagger
+  trade_item: Falcon
+- race: elf
+  occupation: Elven forester
+  starting_weapon: Staff
+  trade_item: Herbs (1 lb.)
+  weight: 2
+- race: elf
+  occupation: Elven glassblower
+  starting_weapon: Hammer (as club)
+  trade_item: Glass beads
+- race: elf
+  occupation: Elven navigator
+  starting_weapon: Shortbow
+  trade_item: Spyglass
+- race: elf
+  occupation: Elven sage
+  starting_weapon: Dagger
+  trade_item: Parchment, quill
+  weight: 2
+- race: human
+  occupation: Farmer
+  starting_weapon: Pitchfork (as spear)
+  # TODO support subtables
+  trade_item: Hen
+  weight: 9
+- race: human
+  occupation: Fortune-teller
+  starting_weapon: Dagger
+  trade_item: Tarot deck
+- race: human
+  occupation: Gambler
+  starting_weapon: Club
+  trade_item: Dice
+- race: human
+  occupation: Gongfarmer
+  starting_weapon: Trowel (as dagger)
+  trade_item: Sack of night soil
+- race: human
+  occupation: Grave digger
+  starting_weapon: Shovel (as staff)
+  trade_item: Trowel
+  weight: 2
+- race: human
+  occupation: Guild beggar
+  starting_weapon: Sling
+  trade_item: Crutches
+  weight: 2
+- race: halfling
+  occupation: Halfling chicken butcher
+  starting_weapon: Handaxe
+  trade_item: Chicken meat (5 lbs.)
+- race: halfling
+  occupation: Halfling dyer
+  starting_weapon: Staff
+  trade_item: Fabric (3 yards)
+  weight: 2
+- race: halfling
+  occupation: Halfling glovemaker
+  starting_weapon: Awl (as dagger)
+  trade_item: Gloves (4 pairs)
+- race: halfling
+  occupation: Halfling gypsy
+  starting_weapon: Sling
+  trade_item: Hex doll
+- race: halfling
+  occupation: Halfling haberdasher
+  starting_weapon: Scissors (as dagger)
+  trade_item: Fine suits (3 sets)
+- race: halfling
+  occupation: Halfling mariner
+  starting_weapon: Knife (as dagger)
+  trade_item: Sailcloth (2 yards)
+- race: halfling
+  occupation: Halfling moneylender
+  starting_weapon: Short sword
+  trade_item: 5 gp, 10 sp, 200 cp
+- race: halfling
+  occupation: Halfling trader
+  starting_weapon: Short sword
+  trade_item: 20 sp
+- race: halfling
+  occupation: Halfling vagrant
+  starting_weapon: Club
+  trade_item: Begging bowl
+- race: human
+  occupation: Healer
+  starting_weapon: Club
+  trade_item: Vial of holy water
+- race: human
+  occupation: Herbalist
+  starting_weapon: Club
+  trade_item: Herbs (1 lb.)
+- race: human
+  occupation: Herder
+  starting_weapon: Staff
+  trade_item: Herding dog
+- race: human
+  occupation: Hunter
+  starting_weapon: Shortbow
+  trade_item: Deer pelt
+  weight: 2
+- race: human
+  occupation: Indentured servant
+  starting_weapon: Staff
+  trade_item: Locket
+- race: human
+  occupation: Jester
+  starting_weapon: Dart
+  trade_item: Silk clothes
+- race: human
+  occupation: Jeweler
+  starting_weapon: Dagger
+  trade_item: Gem worth 20 gp
+- race: human
+  occupation: Locksmith
+  starting_weapon: Dagger
+  trade_item: Fine tools
+- race: human
+  occupation: Mendicant
+  starting_weapon: Club
+  trade_item: Cheese dip
+- race: human
+  occupation: Mercenary
+  starting_weapon: Longsword
+  trade_item: Hide armor (+3 AC, -3 Check, d12 Fumble)
+- race: human
+  occupation: Merchant
+  starting_weapon: Dagger
+  trade_item: 4gp, 14 sp, 27 cp
+- race: human
+  occupation: Miller/baker
+  starting_weapon: Club
+  trade_item: Flour (1 lb.)
+- race: human
+  occupation: Minstrel
+  starting_weapon: Dagger
+  trade_item: Ukulele
+- race: human
+  occupation: Noble
+  starting_weapon: Longsword
+  trade_item: Gold ring worth 10 gp
+- race: human
+  occupation: Orphan
+  starting_weapon: Club
+  trade_item: Rag doll
+- race: human
+  occupation: Ostler
+  starting_weapon: Staff
+  trade_item: Bridle
+- race: human
+  occupation: Outlaw
+  starting_weapon: Short sword
+  trade_item: Leather armor (AC +2, -1 Check, d8 Fumble)
+- race: human
+  occupation: Rope maker
+  starting_weapon: Knife (as dagger)
+  trade_item: Rope (100')
+- race: human
+  occupation: Scribe
+  starting_weapon: Dart
+  trade_item: Parchment (10 sheets)
+- race: human
+  occupation: Shaman
+  starting_weapon: Mace
+  trade_item: Herbs (1 lb.)
+- race: human
+  occupation: Slave
+  starting_weapon: Club
+  trade_item: Strange-looking rock
+- race: human
+  occupation: Smuggler
+  starting_weapon: Sling
+  trade_item: Waterproof sack
+- race: human
+  occupation: Soldier
+  starting_weapon: Spear
+  trade_item: Shield (AC +1, Check -1)
+- race: human
+  occupation: Squire
+  starting_weapon: Longsword
+  trade_item: Steel helmet
+  weight: 2
+- race: human
+  occupation: Tax collector
+  starting_weapon: Longsword
+  trade_item: 100 cp
+- race: human
+  occupation: Trapper
+  starting_weapon: Sling
+  trade_item: Badger pelt
+  weight: 2
+- race: human
+  occupation: Urchin
+  starting_weapon: Stick (as club)
+  trade_item: Begging bowl
+- race: human
+  occupation: Wainwright
+  starting_weapon: Club
+  trade_item: Pushcart
+- race: human
+  occupation: Weaver
+  starting_weapon: Dagger
+  trade_item: Fine suit of clothes
+- race: human
+  occupation: Wizard's apprentice
+  starting_weapon: Dagger
+  trade_item: Black grimoire
+- race: human
+  occupation: Woodcutter
+  starting_weapon: Handaxe
+  trade_item: Bundle of wood
+  weight: 3
+Occupations-Crawl-data: &occupations_crawl_data
+- race: gnome
+  occupation: Gnome gardener
+  starting_weapon: Hand garden fork (as dagger)
+  trade_item: Bag of flower weeds, green thumbs
+- race: gnome
+  occupation: Gnome entertainer
+  starting_weapon: Black wand (as staff)
+  trade_item: Shiny black top hat, white gloves
+- race: gnome
+  occupation: Gnome stroller
+  starting_weapon: Walking stick (as staff)
+  trade_item: Pants with large pockets (holding small rocks, thread)
+Occupations-Crawl:
+ - *occupations_core
+ - *occupations_crawl_data
+Occupations-CUaBM:
+- occupation: Accountant
+  starting_weapon: Big Ledger (as Screwdriver)
+  trade_item: Solar calculator
+- occupation: Armorer
+  starting_weapon: Sledge Hammer
+  trade_item: Retread armor (as studded)
+- occupation: Biker
+  starting_weapon: Length of Chain (as hoe)
+  trade_item: Leather Jacket (as Leather)
+- occupation: Brewer
+  starting_weapon: Bung Hammer (as club)
+  trade_item: 1d3 gallons of booze
+- occupation: Carpenter
+  starting_weapon: Claw Hammer (as hoe)
+  trade_item: Bag of 2d30 nails
+- occupation: Chemist
+  starting_weapon: Vial of mild acid
+  trade_item: 1d3 Molotove cocktails (Era 3)
+- occupation: Cook
+  starting_weapon: Cleaver (as hoe)
+  trade_item: 3d4 trial rations
+- occupation: Electrician
+  starting_weapon: Screwdriver
+  trade_item: Bag of wires and bits
+- occupation: Farmer
+  starting_weapon: Hoe
+  trade_item: 1 Farm animal
+- occupation: Ganger
+  starting_weapon: Slingshot and bag of bearings
+  trade_item: 1 bottle of good booze
+- occupation: Guard
+  starting_weapon: Spear
+  trade_item: Leather armor
+- occupation: Gunsmith
+  starting_weapon: rebuilt revolver
+  trade_item: 3d4 good bullets
+- occupation: Handyman
+  starting_weapon: Large tool (as club)
+  trade_item: Tool belt with 1d3+1 tools
+- occupation: Historian
+  starting_weapon: Heavy book (as screwdriver)
+  trade_item: Trivia (+3 to checks)
+- occupation: Janitor
+  starting_weapon: Large mop (as screwdriver)
+  trade_item: 5 gal bucket and rags
+- occupation: Livestock Rancher
+  starting_weapon: Crook staff (as hoe)
+  trade_item: 1d3 Farm animals
+- occupation: Mechanic
+  starting_weapon: Tire iron (as spear)
+  trade_item: 1d3 gallons of used oil
+- occupation: Medic
+  starting_weapon: Scalpel (as club)
+  trade_item: First aid kit
+- occupation: Merchant
+  starting_weapon: Big Maglite (batteries charged) (as club)
+  trade_item: 1d3 rolls on Equipment table
+- occupation: Miner
+  starting_weapon: Pickaxe (as hoe)
+  trade_item: Filtered mask
+- occupation: Nurse
+  starting_weapon: Scalpel (as club)
+  trade_item: Stethoscope
+- occupation: Peddler
+  starting_weapon: Iron skillet (as hoe)
+  trade_item: 1d3 rolls on Equipment table
+- occupation: Pharmacist
+  starting_weapon: Knife
+  trade_item: 2d3 bottles of drugs
+- occupation: Plumber
+  starting_weapon: Wrench (as club)
+  trade_item: 2d3 copper pipes
+- occupation: Researcher
+  starting_weapon: Heavy book (as screwdriver)
+  trade_item: 1d6 more books
+- occupation: Scavenger
+  starting_weapon: Crowbar (as spear)
+  trade_item: 1d3 rolls on Equipment table
+- occupation: Scientist
+  starting_weapon: Bunsen burner & propane tank (as screwdriver)
+  trade_item: rubber gloves and goggles
+- occupation: Scout
+  starting_weapon: Crossbow and 3d4 bolts
+  trade_item: Compass
+- occupation: Soldier
+  starting_weapon: Bolt action rifle w/bayonet (Bayonet 1d6)
+  trade_item: 2d4 bullets
+- occupation: Wanderer
+  starting_weapon: Big walking stick (as hoe)
+  trade_item: Large backpack

--- a/data/pushcart.yml
+++ b/data/pushcart.yml
@@ -1,0 +1,8 @@
+---
+Pushcart-Core: &pushcart_core
+- Pushcart full of tomatoes
+- Empty pushcart
+- Pushcart full of straw
+- Pushcart full of your dead
+- Pushcart full of dirt
+- Pushcart full of rocks

--- a/data/weapons.yml
+++ b/data/weapons.yml
@@ -1,0 +1,225 @@
+---
+Weapons-Core:
+- type: melee
+  name: Battleaxe
+  dmg_die: 1d10
+  hands: 2
+- type: melee
+  name: Blackjack
+  dmg_die: 1d3
+  backstab_die: 2d6
+  hands: 1
+  subdual: true
+- type: ranged
+  name: Blowgun
+  dmg_die: 1d3
+  backstab_die: 1d5
+  hands: 1
+  ranges:
+    s: 20
+    m: 40
+    l: 60
+  str_bonus: false
+- type: melee
+  name: Club
+  dmg_die: 1d4
+  hands: 1
+- type: ranged
+  name: Crossbow
+  dmg_die: 1d6
+  hands: 2
+  ranges:
+    s: 80
+    m: 160
+    l: 240
+  str_bonus: false
+- type: both
+  name: Dagger
+  dmg_die: 1d4
+  backstab_die: 1d10
+  hands: 1
+  ranges:
+    s: 10
+    m: 20
+    l: 30
+  str_bonus: true
+- type: ranged
+  name: Dart
+  dmg_die: 1d4
+  hands: 1
+  ranges:
+    s: 20
+    m: 40
+    l: 60
+  str_bonus: true
+- type: melee
+  name: Flail
+  dmg_die: 1d6
+  hands: 1
+- type: melee
+  name: Garrote
+  dmg_die: 1
+  backstab_die: 3d4
+  hands: 1
+- type: both
+  name: Handaxe
+  dmg_die: 1d6
+  hands: 1
+  ranges:
+    s: 10
+    m: 20
+    l: 30
+  str_bonus: true
+- type: ranged
+  name: Javelin
+  dmg_die: 1d6
+  hands: 1
+  ranges:
+    s: 30
+    m: 60
+    l: 90
+  str_bonus: true
+- type: melee
+  name: Lance
+  dmg_die: 1d12
+  hands: 1
+  requires_mount: true
+  double_dmg_on_charge: true
+- type: ranged
+  name: Longbow
+  dmg_die: 1d6
+  hands: 2
+  ranges:
+    s: 70
+    m: 140
+    l: 210
+  str_bonus: false
+- type: melee
+  name: Longsword
+  dmg_die: 1d8
+  hands: 1
+- type: melee
+  name: Mace
+  dmg_die: 1d6
+  hands: 1
+- type: melee
+  name: Polearm
+  dmg_die: 1d10
+  hands: 2
+- type: ranged
+  name: Shortbow
+  dmg_die: 1d6
+  hands: 2
+  ranges:
+    s: 50
+    m: 100
+    l: 150
+  str_bonus: false
+- type: melee
+  name: Short sword
+  dmg_die: 1d6
+  hands: 1
+- type: ranged
+  name: Sling
+  dmg_die: 1d4
+  hands: 1
+  ranges:
+    s: 40
+    m: 80
+    l: 160
+  str_bonus: true
+- type: melee
+  name: Spear
+  dmg_die: 1d8
+  hands: 1
+- type: melee
+  name: Staff
+  dmg_die: 1d4
+  hands: 1
+- type: melee
+  name: Two-handed sword
+  dmg_die: 1d10
+  hands: 2
+- type: melee
+  name: Warhammer
+  dmg_die: 1d8
+  hands: 1
+Weapons-CUaBM:
+- type: melee
+  name: Club
+  dmg_die: 1d4
+  hands: 1
+- type: melee
+  name: Screwdriver
+  dmg_die: 1d3
+  hands: 1
+- type: melee
+  name: Sledge Hammer
+  dmg_die: 1d7
+  hands: 2
+- type: melee
+  name: Length of chain
+  dmg_die: 1d5
+  hands: 1
+- type: melee
+  name: Hoe
+  dmg_die: 1d5
+  hands: 1
+- type: melee
+  name: Spear
+  dmg_die: 1d6
+  hands: 1
+- type: ranged
+  name: Vial of mild acid
+  dmg_die: 1d4
+  hands: 1
+  ranges:
+    s: 10
+    m: 20
+    l: 30
+  str_bonus: false
+- type: ranged
+  name: Slingshot and bag of bearings
+  dmg_die: 1d4
+  hands: 1
+  ranges:
+    s: 40
+    m: 80
+    l: 160
+  str_bonus: false
+- type: ranged
+  name: Rebuilt revolver
+  dmg_die: 1d6
+  hands: 1
+  ranges:
+    s: 50
+    m: 100
+    l: 150
+  str_bonus: false
+- type: both
+  name: Knife
+  dmg_die: 1d3
+  hands: 1
+  ranges:
+    s: 10
+    m: 20
+    l: 30
+  str_bonus: true
+- type: ranged
+  name: Crossbow and 3d4 bolts
+  dmg_die: 1d6
+  hands: 1
+  ranges:
+    s: 80
+    m: 160
+    l: 240
+  str_bonus: false
+- type: ranged
+  name: Bolt action rifle w/bayonet (bayonet 1d6)
+  dmg_die: 1d10
+  hands: 1
+  ranges:
+    s: 120
+    m: 240
+    l: 360
+  str_bonus: false

--- a/generate_roll20_tables.rb
+++ b/generate_roll20_tables.rb
@@ -39,6 +39,17 @@ class Fodder
     result
   end
 
+  def build_simple_table(name, theme)
+    result = ""
+    table_name = "#{name}-#{theme}"
+    result += "!import-table --#{table_name} --show\n"
+    entries = YAML.load_file("./data/#{name.downcase.gsub(/-/, '_')}.yml")[table_name].flatten
+    entries.each do |entry|
+      result += "!import-table-item --#{table_name} --#{entry} --1 --\n"
+    end
+    result
+  end
+
   def build_birth_augur_table
     result = ""
     table_name = "Birth-Augur-Lucky-Roll-Core"
@@ -87,6 +98,9 @@ end
 
 fodder = Fodder.new
 
+fodder.write_table("Farmer", "Core", fodder.build_simple_table("Farmer", "Core"))
+fodder.write_table("Farm-Animals", "Core", fodder.build_simple_table("Farm-Animals", "Core"))
+fodder.write_table("Pushcart", "Core", fodder.build_simple_table("Pushcart", "Core"))
 fodder.write_table("Birth-Augur-Lucky-Roll", "Core", fodder.build_birth_augur_table)
 fodder.write_table("Equipment", "Core", fodder.build_equipment_table("Core"))
 fodder.write_table("Equipment", "CUaBM", fodder.build_equipment_table("CUaBM"))

--- a/generate_roll20_tables.rb
+++ b/generate_roll20_tables.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+
+# Reads the .yml files in ./data/ and emits !import-table commands to be used
+# in roll20
+
+require 'yaml'
+
+class Fodder
+  WEAPONS_TABLE_FILE="./data/weapons.yml"
+  OCCUPATIONS_TABLE_FILE="./data/occupations.yml"
+  BIRTH_AUGUR_TABLE_FILE="./data/birth_augur.yml"
+  EQUIPMENT_TABLE_FILE="./data/equipment.yml"
+  WEAPONS = YAML.load_file(WEAPONS_TABLE_FILE)
+
+  def build_weapons_table
+    result = ""
+    table_name = "Weapons-Core"
+    result += "!import-table --#{table_name} --show\n"
+    weapons = YAML.load_file(WEAPONS_TABLE_FILE)
+    weapons.each do |weapon|
+      str_bonus = weapon["str_bonus"] ? "Thrown" : "Normal"
+      ranged_data = weapon["ranges"] ? weapon["ranges"].values.sort.join("/") : ""
+      item = [weapon["type"], weapon["name"], weapon["dmg_die"], weapon["hands"], ranged_data, str_bonus].join("|");
+      result += "!import-table-item --#{table_name} --#{item} --1 --\n"
+    end
+    result
+  end
+
+  def build_weapon_item(weapon, name=nil)
+    str_bonus = weapon["str_bonus"] ? "Thrown" : weapon["type"] == "melee" ? "" : "Normal"
+    ranged_data = weapon["ranges"] ? weapon["ranges"].values.sort.join("/") : ""
+    name ||= weapon["name"]
+    [weapon["type"], name, weapon["dmg_die"], weapon["hands"], ranged_data, str_bonus].join("|");
+  end
+
+  def find_weapon(name, theme)
+    result = WEAPONS["Weapons-#{theme}"].find { |weapon| weapon["name"].downcase == name.downcase }
+    raise "Weapon not found under theme '#{theme}': #{name}" unless result
+    result
+  end
+
+  def build_birth_augur_table
+    result = ""
+    table_name = "Birth-Augur-Lucky-Roll-Core"
+    result += "!import-table --#{table_name} --show\n"
+    augurs = YAML.load_file(BIRTH_AUGUR_TABLE_FILE)["Birth-Augur-Lucky-Roll-Core"].flatten
+    augurs.each do |augur|
+      item = %w[birth_augur lucky_roll attr].map{|key| augur[key]}.join(":")
+      result += "!import-table-item --#{table_name} --#{item} --1 --\n"
+    end
+    result
+  end
+
+  def build_equipment_table(theme)
+    result = ""
+    table_name = "Equipment-#{theme}"
+    result += "!import-table --#{table_name} --show\n"
+    equipment = YAML.load_file(EQUIPMENT_TABLE_FILE)["Equipment-#{theme}"].flatten
+    equipment.each do |e|
+      result += "!import-table-item --#{table_name} --#{e} --1 --\n"
+    end
+    result
+  end
+
+  def build_occupations_table(theme, weapons_theme: "Core")
+    result = ""
+    table_name = "Occupations-#{theme}"
+    result += "!import-table --#{table_name} --show\n"
+    occupations = YAML.load_file(OCCUPATIONS_TABLE_FILE)["Occupations-#{theme}"].flatten
+    occupations.each do |occupation|
+      weapon = occupation["starting_weapon"]
+      if weapon =~ /(.*) \(as (.*)\)/
+        weapon_alias = $1
+        weapon = $2
+      end
+      weapon_data = build_weapon_item(find_weapon(weapon, weapons_theme), weapon_alias)
+      item = [occupation["occupation"], weapon_data, occupation["trade_item"]].join(":")
+      result += "!import-table-item --#{table_name} --#{item} --#{occupation["weight"] || 1} --\n"
+    end
+    result
+  end
+
+  def write_table(table_prefix, theme, data)
+    File.write("./tables/individual/#{table_prefix}-#{theme}.txt", data)
+  end
+end
+
+fodder = Fodder.new
+
+fodder.write_table("Birth-Augur-Lucky-Roll", "Core", fodder.build_birth_augur_table)
+fodder.write_table("Equipment", "Core", fodder.build_equipment_table("Core"))
+fodder.write_table("Equipment", "CUaBM", fodder.build_equipment_table("CUaBM"))
+fodder.write_table("Occupations", "Core", fodder.build_occupations_table("Core"))
+fodder.write_table("Occupations", "Crawl", fodder.build_occupations_table("Crawl"))
+fodder.write_table("Occupations", "CUaBM", fodder.build_occupations_table("CUaBM", weapons_theme: "CUaBM"))
+
+# build the global file:
+`ls tables/individual/*.txt | xargs cat > tables/Global.txt`

--- a/tables/Global.txt
+++ b/tables/Global.txt
@@ -104,6 +104,25 @@
 !import-table-item --Equipment-Core --Thieves' tools --1 --
 !import-table-item --Equipment-Core --Torch --1 --
 !import-table-item --Equipment-Core --Waterskin --1 --
+!import-table --Farm-Animals-Core --show
+!import-table-item --Farm-Animals-Core --Hen --1 --
+!import-table-item --Farm-Animals-Core --Sheep --1 --
+!import-table-item --Farm-Animals-Core --Goat --1 --
+!import-table-item --Farm-Animals-Core --Cow --1 --
+!import-table-item --Farm-Animals-Core --Duck --1 --
+!import-table-item --Farm-Animals-Core --Goose --1 --
+!import-table-item --Farm-Animals-Core --Mule --1 --
+!import-table-item --Farm-Animals-Core --Herding Dog --1 --
+!import-table-item --Farm-Animals-Core --Sow --1 --
+!import-table --Farmer-Core --show
+!import-table-item --Farmer-Core --Potato Farmer --1 --
+!import-table-item --Farmer-Core --Wheat Farmer --1 --
+!import-table-item --Farmer-Core --Turnip Farmer --1 --
+!import-table-item --Farmer-Core --Corn Farmer --1 --
+!import-table-item --Farmer-Core --Rice Farmer --1 --
+!import-table-item --Farmer-Core --Parsnip Farmer --1 --
+!import-table-item --Farmer-Core --Radish Farmer --1 --
+!import-table-item --Farmer-Core --Rutabega Farmer --1 --
 !import-table --Occupations-CUaBM --show
 !import-table-item --Occupations-CUaBM --Accountant:melee|Big Ledger|1d3|1||:Solar calculator --1 --
 !import-table-item --Occupations-CUaBM --Armorer:melee|Sledge Hammer|1d7|2||:Retread armor (as studded) --1 --
@@ -157,7 +176,7 @@
 !import-table-item --Occupations-Core --Dwarven apothecarist:melee|Cudgel|1d4|1||:Steel vial --1 --
 !import-table-item --Occupations-Core --Dwarven blacksmith:melee|Hammer|1d4|1||:Mithril (1 oz.) --1 --
 !import-table-item --Occupations-Core --Dwarven chest-maker:both|Chisel|1d4|1|10/20/30|Thrown:Wood (10 lbs.) --1 --
-!import-table-item --Occupations-Core --Dwarven herder:melee|Staff|1d4|1||:Sow --1 --
+!import-table-item --Occupations-Core --Dwarven herder:melee|Staff|1d4|1||:$subtable-Farm-Animals-Core --1 --
 !import-table-item --Occupations-Core --Dwarven miner:melee|Pick|1d4|1||:Lantern --2 --
 !import-table-item --Occupations-Core --Dwarven mushroom-farmer:melee|Shovel|1d4|1||:Sack --1 --
 !import-table-item --Occupations-Core --Dwarven rat-catcher:melee|Club|1d4|1||:Net --1 --
@@ -170,7 +189,7 @@
 !import-table-item --Occupations-Core --Elven glassblower:melee|Hammer|1d4|1||:Glass beads --1 --
 !import-table-item --Occupations-Core --Elven navigator:ranged|Shortbow|1d6|2|50/100/150|Normal:Spyglass --1 --
 !import-table-item --Occupations-Core --Elven sage:both|Dagger|1d4|1|10/20/30|Thrown:Parchment, quill --2 --
-!import-table-item --Occupations-Core --Farmer:melee|Pitchfork|1d8|1||:Hen --9 --
+!import-table-item --Occupations-Core --$subtable-Farmer-Core:melee|Pitchfork|1d8|1||:$subtable-Farm-Animals-Core --9 --
 !import-table-item --Occupations-Core --Fortune-teller:both|Dagger|1d4|1|10/20/30|Thrown:Tarot deck --1 --
 !import-table-item --Occupations-Core --Gambler:melee|Club|1d4|1||:Dice --1 --
 !import-table-item --Occupations-Core --Gongfarmer:both|Trowel|1d4|1|10/20/30|Thrown:Sack of night soil --1 --
@@ -187,7 +206,7 @@
 !import-table-item --Occupations-Core --Halfling vagrant:melee|Club|1d4|1||:Begging bowl --1 --
 !import-table-item --Occupations-Core --Healer:melee|Club|1d4|1||:Vial of holy water --1 --
 !import-table-item --Occupations-Core --Herbalist:melee|Club|1d4|1||:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Core --Herder:melee|Staff|1d4|1||:Herding dog --1 --
+!import-table-item --Occupations-Core --Herder:melee|Staff|1d4|1||:$subtable-Farm-Animals-Core --1 --
 !import-table-item --Occupations-Core --Hunter:ranged|Shortbow|1d6|2|50/100/150|Normal:Deer pelt --2 --
 !import-table-item --Occupations-Core --Indentured servant:melee|Staff|1d4|1||:Locket --1 --
 !import-table-item --Occupations-Core --Jester:ranged|Dart|1d4|1|20/40/60|Thrown:Silk clothes --1 --
@@ -212,7 +231,7 @@
 !import-table-item --Occupations-Core --Tax collector:melee|Longsword|1d8|1||:100 cp --1 --
 !import-table-item --Occupations-Core --Trapper:ranged|Sling|1d4|1|40/80/160|Thrown:Badger pelt --2 --
 !import-table-item --Occupations-Core --Urchin:melee|Stick|1d4|1||:Begging bowl --1 --
-!import-table-item --Occupations-Core --Wainwright:melee|Club|1d4|1||:Pushcart --1 --
+!import-table-item --Occupations-Core --Wainwright:melee|Club|1d4|1||:$subtable-Pushcart-Core --1 --
 !import-table-item --Occupations-Core --Weaver:both|Dagger|1d4|1|10/20/30|Thrown:Fine suit of clothes --1 --
 !import-table-item --Occupations-Core --Wizard's apprentice:both|Dagger|1d4|1|10/20/30|Thrown:Black grimoire --1 --
 !import-table-item --Occupations-Core --Woodcutter:both|Handaxe|1d6|1|10/20/30|Thrown:Bundle of wood --3 --
@@ -238,7 +257,7 @@
 !import-table-item --Occupations-Crawl --Dwarven apothecarist:melee|Cudgel|1d4|1||:Steel vial --1 --
 !import-table-item --Occupations-Crawl --Dwarven blacksmith:melee|Hammer|1d4|1||:Mithril (1 oz.) --1 --
 !import-table-item --Occupations-Crawl --Dwarven chest-maker:both|Chisel|1d4|1|10/20/30|Thrown:Wood (10 lbs.) --1 --
-!import-table-item --Occupations-Crawl --Dwarven herder:melee|Staff|1d4|1||:Sow --1 --
+!import-table-item --Occupations-Crawl --Dwarven herder:melee|Staff|1d4|1||:$subtable-Farm-Animals-Core --1 --
 !import-table-item --Occupations-Crawl --Dwarven miner:melee|Pick|1d4|1||:Lantern --2 --
 !import-table-item --Occupations-Crawl --Dwarven mushroom-farmer:melee|Shovel|1d4|1||:Sack --1 --
 !import-table-item --Occupations-Crawl --Dwarven rat-catcher:melee|Club|1d4|1||:Net --1 --
@@ -251,7 +270,7 @@
 !import-table-item --Occupations-Crawl --Elven glassblower:melee|Hammer|1d4|1||:Glass beads --1 --
 !import-table-item --Occupations-Crawl --Elven navigator:ranged|Shortbow|1d6|2|50/100/150|Normal:Spyglass --1 --
 !import-table-item --Occupations-Crawl --Elven sage:both|Dagger|1d4|1|10/20/30|Thrown:Parchment, quill --2 --
-!import-table-item --Occupations-Crawl --Farmer:melee|Pitchfork|1d8|1||:Hen --9 --
+!import-table-item --Occupations-Crawl --$subtable-Farmer-Core:melee|Pitchfork|1d8|1||:$subtable-Farm-Animals-Core --9 --
 !import-table-item --Occupations-Crawl --Fortune-teller:both|Dagger|1d4|1|10/20/30|Thrown:Tarot deck --1 --
 !import-table-item --Occupations-Crawl --Gambler:melee|Club|1d4|1||:Dice --1 --
 !import-table-item --Occupations-Crawl --Gongfarmer:both|Trowel|1d4|1|10/20/30|Thrown:Sack of night soil --1 --
@@ -268,7 +287,7 @@
 !import-table-item --Occupations-Crawl --Halfling vagrant:melee|Club|1d4|1||:Begging bowl --1 --
 !import-table-item --Occupations-Crawl --Healer:melee|Club|1d4|1||:Vial of holy water --1 --
 !import-table-item --Occupations-Crawl --Herbalist:melee|Club|1d4|1||:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Herder:melee|Staff|1d4|1||:Herding dog --1 --
+!import-table-item --Occupations-Crawl --Herder:melee|Staff|1d4|1||:$subtable-Farm-Animals-Core --1 --
 !import-table-item --Occupations-Crawl --Hunter:ranged|Shortbow|1d6|2|50/100/150|Normal:Deer pelt --2 --
 !import-table-item --Occupations-Crawl --Indentured servant:melee|Staff|1d4|1||:Locket --1 --
 !import-table-item --Occupations-Crawl --Jester:ranged|Dart|1d4|1|20/40/60|Thrown:Silk clothes --1 --
@@ -293,13 +312,20 @@
 !import-table-item --Occupations-Crawl --Tax collector:melee|Longsword|1d8|1||:100 cp --1 --
 !import-table-item --Occupations-Crawl --Trapper:ranged|Sling|1d4|1|40/80/160|Thrown:Badger pelt --2 --
 !import-table-item --Occupations-Crawl --Urchin:melee|Stick|1d4|1||:Begging bowl --1 --
-!import-table-item --Occupations-Crawl --Wainwright:melee|Club|1d4|1||:Pushcart --1 --
+!import-table-item --Occupations-Crawl --Wainwright:melee|Club|1d4|1||:$subtable-Pushcart-Core --1 --
 !import-table-item --Occupations-Crawl --Weaver:both|Dagger|1d4|1|10/20/30|Thrown:Fine suit of clothes --1 --
 !import-table-item --Occupations-Crawl --Wizard's apprentice:both|Dagger|1d4|1|10/20/30|Thrown:Black grimoire --1 --
 !import-table-item --Occupations-Crawl --Woodcutter:both|Handaxe|1d6|1|10/20/30|Thrown:Bundle of wood --3 --
 !import-table-item --Occupations-Crawl --Gnome gardener:both|Hand garden fork|1d4|1|10/20/30|Thrown:Bag of flower weeds, green thumbs --1 --
 !import-table-item --Occupations-Crawl --Gnome entertainer:melee|Black wand|1d4|1||:Shiny black top hat, white gloves --1 --
 !import-table-item --Occupations-Crawl --Gnome stroller:melee|Walking stick|1d4|1||:Pants with large pockets (holding small rocks, thread) --1 --
+!import-table --Pushcart-Core --show
+!import-table-item --Pushcart-Core --Pushcart full of tomatoes --1 --
+!import-table-item --Pushcart-Core --Empty pushcart --1 --
+!import-table-item --Pushcart-Core --Pushcart full of straw --1 --
+!import-table-item --Pushcart-Core --Pushcart full of your dead --1 --
+!import-table-item --Pushcart-Core --Pushcart full of dirt --1 --
+!import-table-item --Pushcart-Core --Pushcart full of rocks --1 --
 !import-table --Races-CUaBM --hide
 !import-table-item --Races-CUaBM --Human --60 --
 !import-table-item --Races-CUaBM --Dwarf --6 --

--- a/tables/Global.txt
+++ b/tables/Global.txt
@@ -1,263 +1,35 @@
-!import-table --Occupations-Core --show
-!import-table-item --Occupations-Core --Alchemist:Melee|Staff|1d4|Blunt|1:Flask of oil --1 --
-!import-table-item --Occupations-Core --Animal trainer:Melee|Club|1d4|Blunt|1:Pony --1 --
-!import-table-item --Occupations-Core --Armorer:Melee|Hammer|1d4|Blunt|1:Iron helmet --1 --
-!import-table-item --Occupations-Core --Astrologer:Melee|Dagger|1d4|Piercing|1:Spyglass --1 --
-!import-table-item --Occupations-Core --Barber:Melee|Razor|1d4|Piercing|1:Scissors --1 --
-!import-table-item --Occupations-Core --Beadle:Melee|Staff|1d4|Blunt|1:Holy symbol --1 --
-!import-table-item --Occupations-Core --Beekeeper:Melee|Staff|1d4|Blunt|1:Jar of honey --1 --
-!import-table-item --Occupations-Core --Blacksmith:Melee|Hammer|1d4|Blunt|1:Steel tongs --1 --
-!import-table-item --Occupations-Core --Butcher:Melee|Cleaver|1d6|Slashing|1:Side of beef --1 --
-!import-table-item --Occupations-Core --Caravan guard:Melee|Short sword|1d6|Slashing|1:Linen (1 yard) --1 --
-!import-table-item --Occupations-Core --Cheesemaker:Melee|Cudgel|1d4|Blunt|1:Stinky cheese --1 --
-!import-table-item --Occupations-Core --Cobbler:Melee|Awl|1d4|Piercing|1:Shoehorn --1 --
-!import-table-item --Occupations-Core --Confidence artist:Melee|Dagger|1d4|Piercing|1:Quality cloak --1 --
-!import-table-item --Occupations-Core --Cooper:Melee|Crowbar|1d4|Blunt|1:Barrel --1 --
-!import-table-item --Occupations-Core --Costermonger:Melee|Knife|1d4|Piercing|1:Fruit --1 --
-!import-table-item --Occupations-Core --Cupurse:Melee|Dagger|1d4|Piercing|1:Small chest --1 --
-!import-table-item --Occupations-Core --Ditch digger:Melee|Shovel|1d4|Blunt|1:Fine dirt (1 lb.) --1 --
-!import-table-item --Occupations-Core --Dwarven Apothecarist:Melee|Cudgel|1d4|Blunt|1:Steel vial --1 --
-!import-table-item --Occupations-Core --Dwarven blacksmith:Melee|Hammer|1d4|Blunt|1:Mithril (1 oz.) --2 --
-!import-table-item --Occupations-Core --Dwarven chest-maker:Melee|Chisel|1d4|Piercing|1:Wood (10 lbs.) --1 --
-!import-table-item --Occupations-Core --Dwarven herder:Melee|Staff|1d4|Blunt|1:Sow --1 --
-!import-table-item --Occupations-Core --Dwarven miner:Melee|Pick|1d4|Piercing|1:Lantern --2 --
-!import-table-item --Occupations-Core --Dwarven mushroom farmer:Melee|Shovel|1d4|Blunt|1:Sack --1 --
-!import-table-item --Occupations-Core --Dwarven rat-catcher:Melee|Club|1d4|Blunt|1:Net --1 --
-!import-table-item --Occupations-Core --Dwarven stonemason:Melee|Hammer|1d4|Blunt|1:Fine stone (10 lbs.) --2 --
-!import-table-item --Occupations-Core --Elven artisan:Mele|Staff|1d4|Blunt|1:Clay (1 lb.) --1 --
-!import-table-item --Occupations-Core --Elven barrister:Melee|Quill|1d4|Piercing|1:Book --1 --
-!import-table-item --Occupations-Core --Elven chandler:Melee|Scissors|1d4|Piercing|1:Candles (20) --1 --
-!import-table-item --Occupations-Core --Elven falconer:Melee|Dagger|1d4|Piercing|1:Falcon --1 --
-!import-table-item --Occupations-Core --Elven Forester:Melee|Staff|1d4|Blunt|1:Herbs (1 lb.) --2 --
-!import-table-item --Occupations-Core --Elven Glassblower:Melee|Hammer|1d4|Blunt|1:Glass beads --1 --
-!import-table-item --Occupations-Core --Elven navigator:Ranged|Short bow|1d6|Piercing|2|50/100/150|Normal:Spyglass --1 --
-!import-table-item --Occupations-Core --Elven sage:Melee|Dagger|1d4|Piercing|1:Parchment, quill --2 --
-!import-table-item --Occupations-Core --Farmer:Melee|Pitchfork|1d8|Piercing|1:Hen --8 --
-!import-table-item --Occupations-Core --Fortune-teller:Melee|Dagger|1d4|Piercing|1:Tarot deck --1 --
-!import-table-item --Occupations-Core --Gambler:Melee|Club|1d4|Blunt|1:Dice --1 --
-!import-table-item --Occupations-Core --Gongfarmer:Melee|Trowel|1d4|Slashing|1:Sack of night soil --1 --
-!import-table-item --Occupations-Core --Grave digger:Melee|Shovel|1d8|Blunt|1:Trowel --2 --
-!import-table-item --Occupations-Core --Guild beggar:Ranged|Sling|1d4|Blunt|1|40/80/160|Thrown:Crutches --2 --
-!import-table-item --Occupations-Core --Halfling chicken butcher:Melee|Hand axe|1d6|Slashing|1:Chicken meat (5 lbs.) --1 --
-!import-table-item --Occupations-Core --Halfling dyer:Melee|Staff|1d4|Blunt|1:Fabric (3 yards) --2 --
-!import-table-item --Occupations-Core --Halfling glovemaker:Melee|Awl|1d4|Piercing|1:Gloves (4 pairs) --1 --
-!import-table-item --Occupations-Core --Halfling gypsy:Ranged|Sling|1d4|1|40/80/160|Thrown:Hex doll --1 --
-!import-table-item --Occupations-Core --Halfling haberdasher:Melee|Scissors|1d4|Piercing|1:Fine suits (3 sets) --1 --
-!import-table-item --Occupations-Core --Halfling mariner:Melee|Knife|1d4|Piercing|1:Sailcloth (2 yards) --1 --
-!import-table-item --Occupations-Core --Halfling moneylender:Melee|Short sword|1d6|Slashing|1:5 gp, 10 sp, 200 cp --1 --
-!import-table-item --Occupations-Core --Halfling trader:Melee|Short sword|1d6|Slashing|1:20 sp --1 --
-!import-table-item --Occupations-Core --Halfling vagrant:Melee|Club|1d6|Blunt|1:Begging bowl --1 --
-!import-table-item --Occupations-Core --Healer:Melee|Club|1d4|Blunt|1:Vial of holy water --1 --
-!import-table-item --Occupations-Core --Herbalist:Melee|Club|1d4|Blunt|1:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Core --Herder:Melee|Staff|1d8|Blunt|1:Herding dog --1 --
-!import-table-item --Occupations-Core --Hunter:Ranged|Short bow|1d6|Piercing|50/100/150|Normal:Deer pelt --2 --
-!import-table-item --Occupations-Core --Indentured servant:Melee|Staff|1d8|Blunt|1:Locket --1 --
-!import-table-item --Occupations-Core --Jester:Ranged|Dart|1d4|Piercing|1|20/40/60|Thrown:Silk clothes --1 --
-!import-table-item --Occupations-Core --Jeweler:Melee|Dagger|1d4|Piercing|1:Gem worth 20 gp --1 --
-!import-table-item --Occupations-Core --Locksmith:Melee|Dagger|1d4|Piercing|1:Fine tools --1 --
-!import-table-item --Occupations-Core --Mendicant:Melee|Club|1d4|Blunt|1:Cheese dip --1 --
-!import-table-item --Occupations-Core --Mercenary:Melee|Longsword|1d8|Slashing|1:Hide armor (+3 AC, -3 Check, d12 Fumble) --1 --
-!import-table-item --Occupations-Core --Merchant:Melee|Dagger|1d4|Piercing|1:4gp, 14 sp, 27 cp --1 --
-!import-table-item --Occupations-Core --Miller/baker:Melee|Club|1d4|Blunt|1:Flour (1 lb.) --1 --
-!import-table-item --Occupations-Core --Minstrel:Melee|Dagger|1d4|Piercing|1:Ukulele --1 --
-!import-table-item --Occupations-Core --Noble:Melee|Longsword|1d8|Slashing|1:Gold ring worth 10 gp --1 --
-!import-table-item --Occupations-Core --Orphan:Melee|Club|1d4|Blunt|1:Rag doll --1 --
-!import-table-item --Occupations-Core --Ostler:Melee|Staff|1d4|Blunt|1:Bridle --1 --
-!import-table-item --Occupations-Core --Outlaw:Melee|Short sword|1d6|Slashing|1:Leather armor (AC +2, -1 Check, d8 Fumble) --1 --
-!import-table-item --Occupations-Core --Rope maker:Melee|Knife|1d4|Piercing|1:Rope (100') --1 --
-!import-table-item --Occupations-Core --Scribe:Ranged|Dart|1d4|Piercing|1|20/40/60|Thrown:Parchment (10 sheets) --1 --
-!import-table-item --Occupations-Core --Shaman:Melee|Mace|1d6|Blunt|1:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Core --Slave:Melee|Club|1d4|Blunt|1:Strange-looking rock --1 --
-!import-table-item --Occupations-Core --Smuggler:Ranged|Sling|1d4|Blunt|40/80/160|Thrown:Waterproof sack --1 --
-!import-table-item --Occupations-Core --Soldier:Melee|Spear|1d8|Piercing|1:Shield (AC +1, Check -1) --1 --
-!import-table-item --Occupations-Core --Squire:Melee|Longsword|1d8|Slashing|1:Steel helmet --2 --
-!import-table-item --Occupations-Core --Tax collector:Melee|Longsword|1d8|Slashing|1:100 cp --1 --
-!import-table-item --Occupations-Core --Trapper:Ranged|Sling|1d4|Blunt|1|40/80/160|Thrown:Badger pelt --2 --
-!import-table-item --Occupations-Core --Urchin:Melee|Stick|1d4|Blunt|1:Begging bowl --1 --
-!import-table-item --Occupations-Core --Wainwright:Melee|Club|1d4|Blunt|1:Pushcart --1 --
-!import-table-item --Occupations-Core --Weaver:Melee|Dagger|1d4|Piercing|1:Fine suit of clothes --1 --
-!import-table-item --Occupations-Core --Wizard's apprentice:Melee|Dagger|1d4|Piercing|1:Black grimoire --1 --
-!import-table-item --Occupations-Core --Woodcutter:Melee|Handaxe|1d6|Slashing|1:Bundle of wood --2 --
 !import-table --Birth-Augur-Lucky-Roll-Core --show
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Harsh winter:All attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --The Bull:Melee attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Fortunate Date:Missile fire attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Raised by wolves:Unarmed attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Conceived on horseback:Mounted attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Born on the battlefield:Damage rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Path of the bear:Melee damage rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Hawkeye:Missile fire damage rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Pack hunter:Attack and damage rolls for 0-level starting weapon --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Born under the loom:Skill checks (including thief skills) --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Fox's cunning:Find / disable traps --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Four-leafed clover:Find secret doors --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Seventh son:Spell checks --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --The raging storm:Spell damage --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Righteous heart:Turn unholy checks --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Survived the plague:Magical Healing --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Lucky sign:Saving throws --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Guardian angel:Saving throws to escape traps --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Survived a spider bite:Saving throws against poison --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Struck by lightning:Reflex saving throws --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Lived through famine:Fortitude saving throws --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Resisted temptation:Willpower saving throws --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Charmed house:Armor class --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Speed of the cobra:Initiative --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Bountiful harvest:Hit points (applies at each level) --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Warrior's arm:Critical hit tables --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Unholy house:Corruption rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --The Broken Star:Fumbles --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Birdsong:Number of languages --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Wild child:Speed (each +1 / -1 = +5' / -5' speed) --1 --
-!import-table --Equipment-Core --show
-!import-table-item --Equipment-Core --Backpack --1 --
-!import-table-item --Equipment-Core --Candle --1 --
-!import-table-item --Equipment-Core --Chain, 10' --1 --
-!import-table-item --Equipment-Core --Chalk, 1 piece --1 --
-!import-table-item --Equipment-Core --Chest, empty --1 --
-!import-table-item --Equipment-Core --Crowbar --1 --
-!import-table-item --Equipment-Core --Flask, empty --1 --
-!import-table-item --Equipment-Core --Flint & steel --1 --
-!import-table-item --Equipment-Core --Grappling hook --1 --
-!import-table-item --Equipment-Core --Hammer, small --1 --
-!import-table-item --Equipment-Core --Holy symbol --1 --
-!import-table-item --Equipment-Core --Holy water, 1 vial --1 --
-!import-table-item --Equipment-Core --Iron spikes (1d3) --1 --
-!import-table-item --Equipment-Core --Lantern --1 --
-!import-table-item --Equipment-Core --Mirror, hand-sized --1 --
-!import-table-item --Equipment-Core --Oil, 1 flask --1 --
-!import-table-item --Equipment-Core --Pole, 10' --1 --
-!import-table-item --Equipment-Core --Rations (1d3 days) --1 --
-!import-table-item --Equipment-Core --Rope, 50' --1 --
-!import-table-item --Equipment-Core --Sack, large --1 --
-!import-table-item --Equipment-Core --Sack, small --1 --
-!import-table-item --Equipment-Core --Thieves' tools --1 --
-!import-table-item --Equipment-Core --Torch (1d3) --1 --
-!import-table-item --Equipment-Core --Waterskin --1 --
-!import-table --Occupations-Crawl --show
-!import-table-item --Occupations-Crawl --Alchemist:Melee|Staff|1d4|Blunt|1:Flask of oil --1 --
-!import-table-item --Occupations-Crawl --Animal trainer:Melee|Club|1d4|Blunt|1:Pony --1 --
-!import-table-item --Occupations-Crawl --Armorer:Melee|Hammer|1d4|Blunt|1:Iron helmet --1 --
-!import-table-item --Occupations-Crawl --Astrologer:Melee|Dagger|1d4|Piercing|1:Spyglass --1 --
-!import-table-item --Occupations-Crawl --Barber:Melee|Razor|1d4|Piercing|1:Scissors --1 --
-!import-table-item --Occupations-Crawl --Beadle:Melee|Staff|1d4|Blunt|1:Holy symbol --1 --
-!import-table-item --Occupations-Crawl --Beekeeper:Melee|Staff|1d4|Blunt|1:Jar of honey --1 --
-!import-table-item --Occupations-Crawl --Blacksmith:Melee|Hammer|1d4|Blunt|1:Steel tongs --1 --
-!import-table-item --Occupations-Crawl --Butcher:Melee|Cleaver|1d6|Slashing|1:Side of beef --1 --
-!import-table-item --Occupations-Crawl --Caravan guard:Melee|Short sword|1d6|Slashing|1:Linen (1 yard) --1 --
-!import-table-item --Occupations-Crawl --Cheesemaker:Melee|Cudgel|1d4|Blunt|1:Stinky cheese --1 --
-!import-table-item --Occupations-Crawl --Cobbler:Melee|Awl|1d4|Piercing|1:Shoehorn --1 --
-!import-table-item --Occupations-Crawl --Confidence artist:Melee|Dagger|1d4|Piercing|1:Quality cloak --1 --
-!import-table-item --Occupations-Crawl --Cooper:Melee|Crowbar|1d4|Blunt|1:Barrel --1 --
-!import-table-item --Occupations-Crawl --Costermonger:Melee|Knife|1d4|Piercing|1:Fruit --1 --
-!import-table-item --Occupations-Crawl --Cupurse:Melee|Dagger|1d4|Piercing|1:Small chest --1 --
-!import-table-item --Occupations-Crawl --Ditch digger:Melee|Shovel|1d4|Blunt|1:Fine dirt (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Dwarven Apothecarist:Melee|Cudgel|1d4|Blunt|1:Steel vial --1 --
-!import-table-item --Occupations-Crawl --Dwarven blacksmith:Melee|Hammer|1d4|Blunt|1:Mithril (1 oz.) --2 --
-!import-table-item --Occupations-Crawl --Dwarven chest-maker:Melee|Chisel|1d4|Piercing|1:Wood (10 lbs.) --1 --
-!import-table-item --Occupations-Crawl --Dwarven herder:Melee|Staff|1d4|Blunt|1:Sow --1 --
-!import-table-item --Occupations-Crawl --Dwarven miner:Melee|Pick|1d4|Piercing|1:Lantern --2 --
-!import-table-item --Occupations-Crawl --Dwarven mushroom farmer:Melee|Shovel|1d4|Blunt|1:Sack --1 --
-!import-table-item --Occupations-Crawl --Dwarven rat-catcher:Melee|Club|1d4|Blunt|1:Net --1 --
-!import-table-item --Occupations-Crawl --Dwarven stonemason:Melee|Hammer|1d4|Blunt|1:Fine stone (10 lbs.) --2 --
-!import-table-item --Occupations-Crawl --Elven artisan:Mele|Staff|1d4|Blunt|1:Clay (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Elven barrister:Melee|Quill|1d4|Piercing|1:Book --1 --
-!import-table-item --Occupations-Crawl --Elven chandler:Melee|Scissors|1d4|Piercing|1:Candles (20) --1 --
-!import-table-item --Occupations-Crawl --Elven falconer:Melee|Dagger|1d4|Piercing|1:Falcon --1 --
-!import-table-item --Occupations-Crawl --Elven Forester:Melee|Staff|1d4|Blunt|1:Herbs (1 lb.) --2 --
-!import-table-item --Occupations-Crawl --Elven Glassblower:Melee|Hammer|1d4|Blunt|1:Glass beads --1 --
-!import-table-item --Occupations-Crawl --Elven navigator:Ranged|Short bow|1d6|Piercing|2|50/100/150|Normal:Spyglass --1 --
-!import-table-item --Occupations-Crawl --Elven sage:Melee|Dagger|1d4|Piercing|1:Parchment, quill --2 --
-!import-table-item --Occupations-Crawl --Farmer:Melee|Pitchfork|1d8|Piercing|1:Hen --8 --
-!import-table-item --Occupations-Crawl --Fortune-teller:Melee|Dagger|1d4|Piercing|1:Tarot deck --1 --
-!import-table-item --Occupations-Crawl --Gambler:Melee|Club|1d4|Blunt|1:Dice --1 --
-!import-table-item --Occupations-Crawl --Gongfarmer:Melee|Trowel|1d4|Slashing|1:Sack of night soil --1 --
-!import-table-item --Occupations-Crawl --Grave digger:Melee|Shovel|1d8|Blunt|1:Trowel --2 --
-!import-table-item --Occupations-Crawl --Guild beggar:Ranged|Sling|1d4|Blunt|1|40/80/160|Thrown:Crutches --2 --
-!import-table-item --Occupations-Crawl --Halfling chicken butcher:Melee|Hand axe|1d6|Slashing|1:Chicken meat (5 lbs.) --1 --
-!import-table-item --Occupations-Crawl --Halfling dyer:Melee|Staff|1d4|Blunt|1:Fabric (3 yards) --2 --
-!import-table-item --Occupations-Crawl --Halfling glovemaker:Melee|Awl|1d4|Piercing|1:Gloves (4 pairs) --1 --
-!import-table-item --Occupations-Crawl --Halfling gypsy:Ranged|Sling|1d4|1|40/80/160|Thrown:Hex doll --1 --
-!import-table-item --Occupations-Crawl --Halfling haberdasher:Melee|Scissors|1d4|Piercing|1:Fine suits (3 sets) --1 --
-!import-table-item --Occupations-Crawl --Halfling mariner:Melee|Knife|1d4|Piercing|1:Sailcloth (2 yards) --1 --
-!import-table-item --Occupations-Crawl --Halfling moneylender:Melee|Short sword|1d6|Slashing|1:5 gp, 10 sp, 200 cp --1 --
-!import-table-item --Occupations-Crawl --Halfling trader:Melee|Short sword|1d6|Slashing|1:20 sp --1 --
-!import-table-item --Occupations-Crawl --Halfling vagrant:Melee|Club|1d6|Blunt|1:Begging bowl --1 --
-!import-table-item --Occupations-Crawl --Healer:Melee|Club|1d4|Blunt|1:Vial of holy water --1 --
-!import-table-item --Occupations-Crawl --Herbalist:Melee|Club|1d4|Blunt|1:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Herder:Melee|Staff|1d8|Blunt|1:Herding dog --1 --
-!import-table-item --Occupations-Crawl --Hunter:Ranged|Short bow|1d6|Piercing|50/100/150|Normal:Deer pelt --2 --
-!import-table-item --Occupations-Crawl --Indentured servant:Melee|Staff|1d8|Blunt|1:Locket --1 --
-!import-table-item --Occupations-Crawl --Jester:Ranged|Dart|1d4|Piercing|1|20/40/60|Thrown:Silk clothes --1 --
-!import-table-item --Occupations-Crawl --Jeweler:Melee|Dagger|1d4|Piercing|1:Gem worth 20 gp --1 --
-!import-table-item --Occupations-Crawl --Locksmith:Melee|Dagger|1d4|Piercing|1:Fine tools --1 --
-!import-table-item --Occupations-Crawl --Mendicant:Melee|Club|1d4|Blunt|1:Cheese dip --1 --
-!import-table-item --Occupations-Crawl --Mercenary:Melee|Longsword|1d8|Slashing|1:Hide armor (+3 AC, -3 Check, d12 Fumble) --1 --
-!import-table-item --Occupations-Crawl --Merchant:Melee|Dagger|1d4|Piercing|1:4gp, 14 sp, 27 cp --1 --
-!import-table-item --Occupations-Crawl --Miller/baker:Melee|Club|1d4|Blunt|1:Flour (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Minstrel:Melee|Dagger|1d4|Piercing|1:Ukulele --1 --
-!import-table-item --Occupations-Crawl --Noble:Melee|Longsword|1d8|Slashing|1:Gold ring worth 10 gp --1 --
-!import-table-item --Occupations-Crawl --Orphan:Melee|Club|1d4|Blunt|1:Rag doll --1 --
-!import-table-item --Occupations-Crawl --Ostler:Melee|Staff|1d4|Blunt|1:Bridle --1 --
-!import-table-item --Occupations-Crawl --Outlaw:Melee|Short sword|1d6|Slashing|1:Leather armor (AC +2, -1 Check, d8 Fumble) --1 --
-!import-table-item --Occupations-Crawl --Rope maker:Melee|Knife|1d4|Piercing|1:Rope (100') --1 --
-!import-table-item --Occupations-Crawl --Scribe:Ranged|Dart|1d4|Piercing|1|20/40/60|Thrown:Parchment (10 sheets) --1 --
-!import-table-item --Occupations-Crawl --Shaman:Melee|Mace|1d6|Blunt|1:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Slave:Melee|Club|1d4|Blunt|1:Strange-looking rock --1 --
-!import-table-item --Occupations-Crawl --Smuggler:Ranged|Sling|1d4|Blunt|40/80/160|Thrown:Waterproof sack --1 --
-!import-table-item --Occupations-Crawl --Soldier:Melee|Spear|1d8|Piercing|1:Shield (AC +1, Check -1) --1 --
-!import-table-item --Occupations-Crawl --Squire:Melee|Longsword|1d8|Slashing|1:Steel helmet --2 --
-!import-table-item --Occupations-Crawl --Tax collector:Melee|Longsword|1d8|Slashing|1:100 cp --1 --
-!import-table-item --Occupations-Crawl --Trapper:Ranged|Sling|1d4|Blunt|1|40/80/160|Thrown:Badger pelt --2 --
-!import-table-item --Occupations-Crawl --Urchin:Melee|Stick|1d4|Blunt|1:Begging bowl --1 --
-!import-table-item --Occupations-Crawl --Wainwright:Melee|Club|1d4|Blunt|1:Pushcart --1 --
-!import-table-item --Occupations-Crawl --Weaver:Melee|Dagger|1d4|Piercing|1:Fine suit of clothes --1 --
-!import-table-item --Occupations-Crawl --Wizard's apprentice:Melee|Dagger|1d4|Piercing|1:Black grimoire --1 --
-!import-table-item --Occupations-Crawl --Woodcutter:Melee|Handaxe|1d6|Slashing|1:Bundle of wood --2 --
-!import-table-item --Occupations-Crawl --Gnome gardener:Melee|Hand garden fork|1d4|Piercing|1:Bag of flower weeds, green thumbs --1 --
-!import-table-item --Occupations-Crawl --Gnome entertainer:Melee|Black wand||1d4|Blunt|1:Shiny black top hat, white gloves --1 --
-!import-table-item --Occupations-Crawl --Gnome stroller:Melee|Walking stick|1d4|Blunt|1:Pants with large pockets (holding small rocks, thread) --1 --
-!import-table --Races-CUaBM --hide
-!import-table-item --Races-CUaBM --Human --60 --
-!import-table-item --Races-CUaBM --Dwarf --6 --
-!import-table-item --Races-CUaBM --Elf --5 --
-!import-table-item --Races-CUaBM --Halfling --6 --
-!import-table-item --Races-CUaBM --Mutant --15 --
-!import-table-item --Races-CUaBM --Robot --1 --
-!import-table-item --Races-CUaBM --Morlock --5 --
-!import-table-item --Races-CUaBM --Reptilian --2 --
-!import-table --Occupations-CUaBM --hide
-!import-table-item --Occupations-CUaBM --Accountant:Big Ledger (1d3):Solar calculator --1 --
-!import-table-item --Occupations-CUaBM --Armorer:Sledge Hammer (1d7, 2-handed):Retread armor (as studded) --1 --
-!import-table-item --Occupations-CUaBM --Biker:Length of Chain (1d5):Leather Jacket (as Leather) --1 --
-!import-table-item --Occupations-CUaBM --Brewer:Bung Hammer (1d4):1d3 gallons of booze --1 --
-!import-table-item --Occupations-CUaBM --Carpenter:Claw Hammer (1d5):Bag of 2d30 nails --1 --
-!import-table-item --Occupations-CUaBM --Chemist:1d6 vials of mild acid (1d4):1d3 Molotove cocktails (Era 3) --1 --
-!import-table-item --Occupations-CUaBM --Cook:Cleaver (1d5):3d4 trial rations --1 --
-!import-table-item --Occupations-CUaBM --Electrician:Screwdriver (1d3):Bag of wires and bits --1 --
-!import-table-item --Occupations-CUaBM --Farmer:Hoe (1d5):1 Farm animal --1 --
-!import-table-item --Occupations-CUaBM --Ganger:Slingshot and bag of bearings (1d4):1 bottle of good booze --1 --
-!import-table-item --Occupations-CUaBM --Guard:Spear (1d6):Leather armor --1 --
-!import-table-item --Occupations-CUaBM --Gunsmith:rebuilt revolver (1d6, range 50ft):3d4 good bullets --1 --
-!import-table-item --Occupations-CUaBM --Handyman:Large tool (1d4):Tool belt with 1d3+1 tools --1 --
-!import-table-item --Occupations-CUaBM --Historian:Heavy book (1d3):Trivia (+3 to checks) --1 --
-!import-table-item --Occupations-CUaBM --Janitor:Large mop (1d3):5 gal bucket and rags --1 --
-!import-table-item --Occupations-CUaBM --Livestock Rancher:Crook staff (1d5):1d3 Farm animals --1 --
-!import-table-item --Occupations-CUaBM --Mechanic:Tire iron (1d6):1d3 gallons of used oil --1 --
-!import-table-item --Occupations-CUaBM --Medic:Scalpel (1d4):First aid kit --1 --
-!import-table-item --Occupations-CUaBM --Merchant:Big Maglite (1d4) (batteries charged):1d3 rolls on Equipment table --1 --
-!import-table-item --Occupations-CUaBM --Miner:Pickaxe (1d5):Filtered mask --1 --
-!import-table-item --Occupations-CUaBM --Nurse:Scalpel (1d4):Stethoscope --1 --
-!import-table-item --Occupations-CUaBM --Peddler:Iron skillet (1d5):1d3 rolls on Equipment table --1 --
-!import-table-item --Occupations-CUaBM --Pharmacist:Knife (1d3):2d3 bottles of drugs --1 --
-!import-table-item --Occupations-CUaBM --Plumber:Wrench (1d4):2d3 copper pipes --1 --
-!import-table-item --Occupations-CUaBM --Researcher:Heavy book (1d3):1d6 more books --1 --
-!import-table-item --Occupations-CUaBM --Scavenger:Crowbar (1d6):1d3 rolls on Equipment table --1 --
-!import-table-item --Occupations-CUaBM --Scientist:Bunsen burner & propane tank (1d3):rubber gloves and goggles --1 --
-!import-table-item --Occupations-CUaBM --Scout:Crossbow and 3d4 bolts:Compass --1 --
-!import-table-item --Occupations-CUaBM --Soldier:Bolt action rifle w/bayonet (1d10, 120ft) (Bayonet 1d6):2d4 bullets --1 --
-!import-table-item --Occupations-CUaBM --Wanderer:big walking stick (1d5):Large backpack --1 --
-!import-table --Equipment-CUaBM --hide
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Harsh winter:All attack rolls:allAtkLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --The Bull:Melee attack rolls:meleeAtkLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Fortunate Date:Missile fire attack rolls:rangedAtkLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Raised by wolves:Unarmed attack rolls: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Conceived on horseback:Mounted attack rolls: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Born on the battlefield:Damage rolls:dmgLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Path of the bear:Melee damage rolls:meleeDmgLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Hawkeye:Missile fire damage rolls:rangedDmgLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Pack hunter:Attack and damage rolls for 0-level starting weapon:special_zeroWeaponLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Born under the loom:Skill checks (including thief skills):skillChecksLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Fox's cunning:Find / disable traps:findDisableTrapsLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Four-leafed clover:Find secret doors:findSecretDoorsLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Seventh son:Spell checks:spellCastLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --The raging storm:Spell damage: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Righteous heart:Turn unholy checks:turnUnholyLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Survived the plague:Magical Healing:layOnHandsLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Lucky sign:Saving throws:savingThrowsLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Guardian angel:Saving throws to escape traps: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Survived a spider bite:Saving throws against poison: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Struck by lightning:Reflex saving throws:reflexLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Lived through famine:Fortitude saving throws:fortitudeLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Resisted temptation:Willpower saving throws:willLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Charmed house:Armor class:armorClassLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Speed of the cobra:Initiative:initLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Bountiful harvest:Hit points (applies at each level):hpLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Warrior's arm:Critical hit tables:critLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Unholy house:Corruption rolls:corruptionLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --The Broken Star:Fumbles:fumbleLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Birdsong:Number of languages: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Wild child:Speed (each +1 / -1 = +5' / -5' speed):speedLuckyRoll --1 --
+!import-table --Equipment-CUaBM --show
 !import-table-item --Equipment-CUaBM --3 Plasticware Containers --1 --
 !import-table-item --Equipment-CUaBM --4 Firestarter Bricks --1 --
 !import-table-item --Equipment-CUaBM --20 Resealable Plastic Bags --1 --
@@ -291,7 +63,7 @@
 !import-table-item --Equipment-CUaBM --Metal Tongs --1 --
 !import-table-item --Equipment-CUaBM --Mirror, Hand-sized --1 --
 !import-table-item --Equipment-CUaBM --Nylon Rope, 50' --1 --
-!import-table-item --Equipment-CUaBM --Oil, 1 flask* --1 --
+!import-table-item --Equipment-CUaBM --Oil, 1 flask --1 --
 !import-table-item --Equipment-CUaBM --Pocket Fisherman --1 --
 !import-table-item --Equipment-CUaBM --Poker Set with Chips --1 --
 !import-table-item --Equipment-CUaBM --Pole, 10' --1 --
@@ -307,3 +79,233 @@
 !import-table-item --Equipment-CUaBM --Utility Knife (1d3) --1 --
 !import-table-item --Equipment-CUaBM --Water Kettle --1 --
 !import-table-item --Equipment-CUaBM --Zippo Lighter with Lighter Fluid --1 --
+!import-table --Equipment-Core --show
+!import-table-item --Equipment-Core --Backpack --1 --
+!import-table-item --Equipment-Core --Candle --1 --
+!import-table-item --Equipment-Core --Chain, 10' --1 --
+!import-table-item --Equipment-Core --Chalk, 1 piece --1 --
+!import-table-item --Equipment-Core --Chest, empty --1 --
+!import-table-item --Equipment-Core --Crowbar --1 --
+!import-table-item --Equipment-Core --Flask, empty --1 --
+!import-table-item --Equipment-Core --Flint & steel --1 --
+!import-table-item --Equipment-Core --Grappling hook --1 --
+!import-table-item --Equipment-Core --Hammer, small --1 --
+!import-table-item --Equipment-Core --Holy symbol --1 --
+!import-table-item --Equipment-Core --Holy water, 1 vial --1 --
+!import-table-item --Equipment-Core --Iron spike --1 --
+!import-table-item --Equipment-Core --Lantern --1 --
+!import-table-item --Equipment-Core --Mirror, hand-sized --1 --
+!import-table-item --Equipment-Core --Oil, 1 flask --1 --
+!import-table-item --Equipment-Core --Pole, 10' --1 --
+!import-table-item --Equipment-Core --Rations, 1 day --1 --
+!import-table-item --Equipment-Core --Rope, 50' --1 --
+!import-table-item --Equipment-Core --Sack, large --1 --
+!import-table-item --Equipment-Core --Sack, small --1 --
+!import-table-item --Equipment-Core --Thieves' tools --1 --
+!import-table-item --Equipment-Core --Torch --1 --
+!import-table-item --Equipment-Core --Waterskin --1 --
+!import-table --Occupations-CUaBM --show
+!import-table-item --Occupations-CUaBM --Accountant:melee|Big Ledger|1d3|1||:Solar calculator --1 --
+!import-table-item --Occupations-CUaBM --Armorer:melee|Sledge Hammer|1d7|2||:Retread armor (as studded) --1 --
+!import-table-item --Occupations-CUaBM --Biker:melee|Length of Chain|1d5|1||:Leather Jacket (as Leather) --1 --
+!import-table-item --Occupations-CUaBM --Brewer:melee|Bung Hammer|1d4|1||:1d3 gallons of booze --1 --
+!import-table-item --Occupations-CUaBM --Carpenter:melee|Claw Hammer|1d5|1||:Bag of 2d30 nails --1 --
+!import-table-item --Occupations-CUaBM --Chemist:ranged|Vial of mild acid|1d4|1|10/20/30|Normal:1d3 Molotove cocktails (Era 3) --1 --
+!import-table-item --Occupations-CUaBM --Cook:melee|Cleaver|1d5|1||:3d4 trial rations --1 --
+!import-table-item --Occupations-CUaBM --Electrician:melee|Screwdriver|1d3|1||:Bag of wires and bits --1 --
+!import-table-item --Occupations-CUaBM --Farmer:melee|Hoe|1d5|1||:1 Farm animal --1 --
+!import-table-item --Occupations-CUaBM --Ganger:ranged|Slingshot and bag of bearings|1d4|1|40/80/160|Normal:1 bottle of good booze --1 --
+!import-table-item --Occupations-CUaBM --Guard:melee|Spear|1d6|1||:Leather armor --1 --
+!import-table-item --Occupations-CUaBM --Gunsmith:ranged|Rebuilt revolver|1d6|1|50/100/150|Normal:3d4 good bullets --1 --
+!import-table-item --Occupations-CUaBM --Handyman:melee|Large tool|1d4|1||:Tool belt with 1d3+1 tools --1 --
+!import-table-item --Occupations-CUaBM --Historian:melee|Heavy book|1d3|1||:Trivia (+3 to checks) --1 --
+!import-table-item --Occupations-CUaBM --Janitor:melee|Large mop|1d3|1||:5 gal bucket and rags --1 --
+!import-table-item --Occupations-CUaBM --Livestock Rancher:melee|Crook staff|1d5|1||:1d3 Farm animals --1 --
+!import-table-item --Occupations-CUaBM --Mechanic:melee|Tire iron|1d6|1||:1d3 gallons of used oil --1 --
+!import-table-item --Occupations-CUaBM --Medic:melee|Scalpel|1d4|1||:First aid kit --1 --
+!import-table-item --Occupations-CUaBM --Merchant:melee|Big Maglite (batteries charged)|1d4|1||:1d3 rolls on Equipment table --1 --
+!import-table-item --Occupations-CUaBM --Miner:melee|Pickaxe|1d5|1||:Filtered mask --1 --
+!import-table-item --Occupations-CUaBM --Nurse:melee|Scalpel|1d4|1||:Stethoscope --1 --
+!import-table-item --Occupations-CUaBM --Peddler:melee|Iron skillet|1d5|1||:1d3 rolls on Equipment table --1 --
+!import-table-item --Occupations-CUaBM --Pharmacist:both|Knife|1d3|1|10/20/30|Thrown:2d3 bottles of drugs --1 --
+!import-table-item --Occupations-CUaBM --Plumber:melee|Wrench|1d4|1||:2d3 copper pipes --1 --
+!import-table-item --Occupations-CUaBM --Researcher:melee|Heavy book|1d3|1||:1d6 more books --1 --
+!import-table-item --Occupations-CUaBM --Scavenger:melee|Crowbar|1d6|1||:1d3 rolls on Equipment table --1 --
+!import-table-item --Occupations-CUaBM --Scientist:melee|Bunsen burner & propane tank|1d3|1||:rubber gloves and goggles --1 --
+!import-table-item --Occupations-CUaBM --Scout:ranged|Crossbow and 3d4 bolts|1d6|1|80/160/240|Normal:Compass --1 --
+!import-table-item --Occupations-CUaBM --Soldier:ranged|Bolt action rifle w/bayonet (bayonet 1d6)|1d10|1|120/240/360|Normal:2d4 bullets --1 --
+!import-table-item --Occupations-CUaBM --Wanderer:melee|Big walking stick|1d5|1||:Large backpack --1 --
+!import-table --Occupations-Core --show
+!import-table-item --Occupations-Core --Alchemist:melee|Staff|1d4|1||:Flask of oil --1 --
+!import-table-item --Occupations-Core --Animal trainer:melee|Club|1d4|1||:Pony --1 --
+!import-table-item --Occupations-Core --Armorer:melee|Hammer|1d4|1||:Iron helmet --1 --
+!import-table-item --Occupations-Core --Astrologer:both|Dagger|1d4|1|10/20/30|Thrown:Spyglass --1 --
+!import-table-item --Occupations-Core --Barber:both|Razor|1d4|1|10/20/30|Thrown:Scissors --1 --
+!import-table-item --Occupations-Core --Beadle:melee|Staff|1d4|1||:Holy symbol --1 --
+!import-table-item --Occupations-Core --Beekeeper:melee|Staff|1d4|1||:Jar of honey --1 --
+!import-table-item --Occupations-Core --Blacksmith:melee|Hammer|1d4|1||:Steel tongs --1 --
+!import-table-item --Occupations-Core --Butcher:both|Cleaver|1d6|1|10/20/30|Thrown:Side of beef --1 --
+!import-table-item --Occupations-Core --Caravan guard:melee|Short sword|1d6|1||:Linen (1 yard) --1 --
+!import-table-item --Occupations-Core --Cheesemaker:melee|Cudgel|1d4|1||:Stinky cheese --1 --
+!import-table-item --Occupations-Core --Cobbler:both|Awl|1d4|1|10/20/30|Thrown:Shoehorn --1 --
+!import-table-item --Occupations-Core --Confidence artist:both|Dagger|1d4|1|10/20/30|Thrown:Quality cloak --1 --
+!import-table-item --Occupations-Core --Cooper:melee|Crowbar|1d4|1||:Barrel --1 --
+!import-table-item --Occupations-Core --Costermonger:both|Knife|1d4|1|10/20/30|Thrown:Fruit --1 --
+!import-table-item --Occupations-Core --Cutpurse:both|Dagger|1d4|1|10/20/30|Thrown:Small chest --1 --
+!import-table-item --Occupations-Core --Ditch digger:melee|Shovel|1d4|1||:Fine dirt (1 lb.) --1 --
+!import-table-item --Occupations-Core --Dock worker:melee|Pole|1d4|1||:1 late RPG book --1 --
+!import-table-item --Occupations-Core --Dwarven apothecarist:melee|Cudgel|1d4|1||:Steel vial --1 --
+!import-table-item --Occupations-Core --Dwarven blacksmith:melee|Hammer|1d4|1||:Mithril (1 oz.) --1 --
+!import-table-item --Occupations-Core --Dwarven chest-maker:both|Chisel|1d4|1|10/20/30|Thrown:Wood (10 lbs.) --1 --
+!import-table-item --Occupations-Core --Dwarven herder:melee|Staff|1d4|1||:Sow --1 --
+!import-table-item --Occupations-Core --Dwarven miner:melee|Pick|1d4|1||:Lantern --2 --
+!import-table-item --Occupations-Core --Dwarven mushroom-farmer:melee|Shovel|1d4|1||:Sack --1 --
+!import-table-item --Occupations-Core --Dwarven rat-catcher:melee|Club|1d4|1||:Net --1 --
+!import-table-item --Occupations-Core --Dwarven stonemason:melee|Hammer|1d4|1||:Fine stone (10 lbs.) --2 --
+!import-table-item --Occupations-Core --Elven artisan:melee|Staff|1d4|1||:Clay (1 lb.) --1 --
+!import-table-item --Occupations-Core --Elven barrister:ranged|Quill|1d4|1|20/40/60|Thrown:Book --1 --
+!import-table-item --Occupations-Core --Elven chandler:both|Scissors|1d4|1|10/20/30|Thrown:Candles (20) --1 --
+!import-table-item --Occupations-Core --Elven falconer:both|Dagger|1d4|1|10/20/30|Thrown:Falcon --1 --
+!import-table-item --Occupations-Core --Elven forester:melee|Staff|1d4|1||:Herbs (1 lb.) --2 --
+!import-table-item --Occupations-Core --Elven glassblower:melee|Hammer|1d4|1||:Glass beads --1 --
+!import-table-item --Occupations-Core --Elven navigator:ranged|Shortbow|1d6|2|50/100/150|Normal:Spyglass --1 --
+!import-table-item --Occupations-Core --Elven sage:both|Dagger|1d4|1|10/20/30|Thrown:Parchment, quill --2 --
+!import-table-item --Occupations-Core --Farmer:melee|Pitchfork|1d8|1||:Hen --9 --
+!import-table-item --Occupations-Core --Fortune-teller:both|Dagger|1d4|1|10/20/30|Thrown:Tarot deck --1 --
+!import-table-item --Occupations-Core --Gambler:melee|Club|1d4|1||:Dice --1 --
+!import-table-item --Occupations-Core --Gongfarmer:both|Trowel|1d4|1|10/20/30|Thrown:Sack of night soil --1 --
+!import-table-item --Occupations-Core --Grave digger:melee|Shovel|1d4|1||:Trowel --2 --
+!import-table-item --Occupations-Core --Guild beggar:ranged|Sling|1d4|1|40/80/160|Thrown:Crutches --2 --
+!import-table-item --Occupations-Core --Halfling chicken butcher:both|Handaxe|1d6|1|10/20/30|Thrown:Chicken meat (5 lbs.) --1 --
+!import-table-item --Occupations-Core --Halfling dyer:melee|Staff|1d4|1||:Fabric (3 yards) --2 --
+!import-table-item --Occupations-Core --Halfling glovemaker:both|Awl|1d4|1|10/20/30|Thrown:Gloves (4 pairs) --1 --
+!import-table-item --Occupations-Core --Halfling gypsy:ranged|Sling|1d4|1|40/80/160|Thrown:Hex doll --1 --
+!import-table-item --Occupations-Core --Halfling haberdasher:both|Scissors|1d4|1|10/20/30|Thrown:Fine suits (3 sets) --1 --
+!import-table-item --Occupations-Core --Halfling mariner:both|Knife|1d4|1|10/20/30|Thrown:Sailcloth (2 yards) --1 --
+!import-table-item --Occupations-Core --Halfling moneylender:melee|Short sword|1d6|1||:5 gp, 10 sp, 200 cp --1 --
+!import-table-item --Occupations-Core --Halfling trader:melee|Short sword|1d6|1||:20 sp --1 --
+!import-table-item --Occupations-Core --Halfling vagrant:melee|Club|1d4|1||:Begging bowl --1 --
+!import-table-item --Occupations-Core --Healer:melee|Club|1d4|1||:Vial of holy water --1 --
+!import-table-item --Occupations-Core --Herbalist:melee|Club|1d4|1||:Herbs (1 lb.) --1 --
+!import-table-item --Occupations-Core --Herder:melee|Staff|1d4|1||:Herding dog --1 --
+!import-table-item --Occupations-Core --Hunter:ranged|Shortbow|1d6|2|50/100/150|Normal:Deer pelt --2 --
+!import-table-item --Occupations-Core --Indentured servant:melee|Staff|1d4|1||:Locket --1 --
+!import-table-item --Occupations-Core --Jester:ranged|Dart|1d4|1|20/40/60|Thrown:Silk clothes --1 --
+!import-table-item --Occupations-Core --Jeweler:both|Dagger|1d4|1|10/20/30|Thrown:Gem worth 20 gp --1 --
+!import-table-item --Occupations-Core --Locksmith:both|Dagger|1d4|1|10/20/30|Thrown:Fine tools --1 --
+!import-table-item --Occupations-Core --Mendicant:melee|Club|1d4|1||:Cheese dip --1 --
+!import-table-item --Occupations-Core --Mercenary:melee|Longsword|1d8|1||:Hide armor (+3 AC, -3 Check, d12 Fumble) --1 --
+!import-table-item --Occupations-Core --Merchant:both|Dagger|1d4|1|10/20/30|Thrown:4gp, 14 sp, 27 cp --1 --
+!import-table-item --Occupations-Core --Miller/baker:melee|Club|1d4|1||:Flour (1 lb.) --1 --
+!import-table-item --Occupations-Core --Minstrel:both|Dagger|1d4|1|10/20/30|Thrown:Ukulele --1 --
+!import-table-item --Occupations-Core --Noble:melee|Longsword|1d8|1||:Gold ring worth 10 gp --1 --
+!import-table-item --Occupations-Core --Orphan:melee|Club|1d4|1||:Rag doll --1 --
+!import-table-item --Occupations-Core --Ostler:melee|Staff|1d4|1||:Bridle --1 --
+!import-table-item --Occupations-Core --Outlaw:melee|Short sword|1d6|1||:Leather armor (AC +2, -1 Check, d8 Fumble) --1 --
+!import-table-item --Occupations-Core --Rope maker:both|Knife|1d4|1|10/20/30|Thrown:Rope (100') --1 --
+!import-table-item --Occupations-Core --Scribe:ranged|Dart|1d4|1|20/40/60|Thrown:Parchment (10 sheets) --1 --
+!import-table-item --Occupations-Core --Shaman:melee|Mace|1d6|1||:Herbs (1 lb.) --1 --
+!import-table-item --Occupations-Core --Slave:melee|Club|1d4|1||:Strange-looking rock --1 --
+!import-table-item --Occupations-Core --Smuggler:ranged|Sling|1d4|1|40/80/160|Thrown:Waterproof sack --1 --
+!import-table-item --Occupations-Core --Soldier:melee|Spear|1d8|1||:Shield (AC +1, Check -1) --1 --
+!import-table-item --Occupations-Core --Squire:melee|Longsword|1d8|1||:Steel helmet --2 --
+!import-table-item --Occupations-Core --Tax collector:melee|Longsword|1d8|1||:100 cp --1 --
+!import-table-item --Occupations-Core --Trapper:ranged|Sling|1d4|1|40/80/160|Thrown:Badger pelt --2 --
+!import-table-item --Occupations-Core --Urchin:melee|Stick|1d4|1||:Begging bowl --1 --
+!import-table-item --Occupations-Core --Wainwright:melee|Club|1d4|1||:Pushcart --1 --
+!import-table-item --Occupations-Core --Weaver:both|Dagger|1d4|1|10/20/30|Thrown:Fine suit of clothes --1 --
+!import-table-item --Occupations-Core --Wizard's apprentice:both|Dagger|1d4|1|10/20/30|Thrown:Black grimoire --1 --
+!import-table-item --Occupations-Core --Woodcutter:both|Handaxe|1d6|1|10/20/30|Thrown:Bundle of wood --3 --
+!import-table --Occupations-Crawl --show
+!import-table-item --Occupations-Crawl --Alchemist:melee|Staff|1d4|1||:Flask of oil --1 --
+!import-table-item --Occupations-Crawl --Animal trainer:melee|Club|1d4|1||:Pony --1 --
+!import-table-item --Occupations-Crawl --Armorer:melee|Hammer|1d4|1||:Iron helmet --1 --
+!import-table-item --Occupations-Crawl --Astrologer:both|Dagger|1d4|1|10/20/30|Thrown:Spyglass --1 --
+!import-table-item --Occupations-Crawl --Barber:both|Razor|1d4|1|10/20/30|Thrown:Scissors --1 --
+!import-table-item --Occupations-Crawl --Beadle:melee|Staff|1d4|1||:Holy symbol --1 --
+!import-table-item --Occupations-Crawl --Beekeeper:melee|Staff|1d4|1||:Jar of honey --1 --
+!import-table-item --Occupations-Crawl --Blacksmith:melee|Hammer|1d4|1||:Steel tongs --1 --
+!import-table-item --Occupations-Crawl --Butcher:both|Cleaver|1d6|1|10/20/30|Thrown:Side of beef --1 --
+!import-table-item --Occupations-Crawl --Caravan guard:melee|Short sword|1d6|1||:Linen (1 yard) --1 --
+!import-table-item --Occupations-Crawl --Cheesemaker:melee|Cudgel|1d4|1||:Stinky cheese --1 --
+!import-table-item --Occupations-Crawl --Cobbler:both|Awl|1d4|1|10/20/30|Thrown:Shoehorn --1 --
+!import-table-item --Occupations-Crawl --Confidence artist:both|Dagger|1d4|1|10/20/30|Thrown:Quality cloak --1 --
+!import-table-item --Occupations-Crawl --Cooper:melee|Crowbar|1d4|1||:Barrel --1 --
+!import-table-item --Occupations-Crawl --Costermonger:both|Knife|1d4|1|10/20/30|Thrown:Fruit --1 --
+!import-table-item --Occupations-Crawl --Cutpurse:both|Dagger|1d4|1|10/20/30|Thrown:Small chest --1 --
+!import-table-item --Occupations-Crawl --Ditch digger:melee|Shovel|1d4|1||:Fine dirt (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Dock worker:melee|Pole|1d4|1||:1 late RPG book --1 --
+!import-table-item --Occupations-Crawl --Dwarven apothecarist:melee|Cudgel|1d4|1||:Steel vial --1 --
+!import-table-item --Occupations-Crawl --Dwarven blacksmith:melee|Hammer|1d4|1||:Mithril (1 oz.) --1 --
+!import-table-item --Occupations-Crawl --Dwarven chest-maker:both|Chisel|1d4|1|10/20/30|Thrown:Wood (10 lbs.) --1 --
+!import-table-item --Occupations-Crawl --Dwarven herder:melee|Staff|1d4|1||:Sow --1 --
+!import-table-item --Occupations-Crawl --Dwarven miner:melee|Pick|1d4|1||:Lantern --2 --
+!import-table-item --Occupations-Crawl --Dwarven mushroom-farmer:melee|Shovel|1d4|1||:Sack --1 --
+!import-table-item --Occupations-Crawl --Dwarven rat-catcher:melee|Club|1d4|1||:Net --1 --
+!import-table-item --Occupations-Crawl --Dwarven stonemason:melee|Hammer|1d4|1||:Fine stone (10 lbs.) --2 --
+!import-table-item --Occupations-Crawl --Elven artisan:melee|Staff|1d4|1||:Clay (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Elven barrister:ranged|Quill|1d4|1|20/40/60|Thrown:Book --1 --
+!import-table-item --Occupations-Crawl --Elven chandler:both|Scissors|1d4|1|10/20/30|Thrown:Candles (20) --1 --
+!import-table-item --Occupations-Crawl --Elven falconer:both|Dagger|1d4|1|10/20/30|Thrown:Falcon --1 --
+!import-table-item --Occupations-Crawl --Elven forester:melee|Staff|1d4|1||:Herbs (1 lb.) --2 --
+!import-table-item --Occupations-Crawl --Elven glassblower:melee|Hammer|1d4|1||:Glass beads --1 --
+!import-table-item --Occupations-Crawl --Elven navigator:ranged|Shortbow|1d6|2|50/100/150|Normal:Spyglass --1 --
+!import-table-item --Occupations-Crawl --Elven sage:both|Dagger|1d4|1|10/20/30|Thrown:Parchment, quill --2 --
+!import-table-item --Occupations-Crawl --Farmer:melee|Pitchfork|1d8|1||:Hen --9 --
+!import-table-item --Occupations-Crawl --Fortune-teller:both|Dagger|1d4|1|10/20/30|Thrown:Tarot deck --1 --
+!import-table-item --Occupations-Crawl --Gambler:melee|Club|1d4|1||:Dice --1 --
+!import-table-item --Occupations-Crawl --Gongfarmer:both|Trowel|1d4|1|10/20/30|Thrown:Sack of night soil --1 --
+!import-table-item --Occupations-Crawl --Grave digger:melee|Shovel|1d4|1||:Trowel --2 --
+!import-table-item --Occupations-Crawl --Guild beggar:ranged|Sling|1d4|1|40/80/160|Thrown:Crutches --2 --
+!import-table-item --Occupations-Crawl --Halfling chicken butcher:both|Handaxe|1d6|1|10/20/30|Thrown:Chicken meat (5 lbs.) --1 --
+!import-table-item --Occupations-Crawl --Halfling dyer:melee|Staff|1d4|1||:Fabric (3 yards) --2 --
+!import-table-item --Occupations-Crawl --Halfling glovemaker:both|Awl|1d4|1|10/20/30|Thrown:Gloves (4 pairs) --1 --
+!import-table-item --Occupations-Crawl --Halfling gypsy:ranged|Sling|1d4|1|40/80/160|Thrown:Hex doll --1 --
+!import-table-item --Occupations-Crawl --Halfling haberdasher:both|Scissors|1d4|1|10/20/30|Thrown:Fine suits (3 sets) --1 --
+!import-table-item --Occupations-Crawl --Halfling mariner:both|Knife|1d4|1|10/20/30|Thrown:Sailcloth (2 yards) --1 --
+!import-table-item --Occupations-Crawl --Halfling moneylender:melee|Short sword|1d6|1||:5 gp, 10 sp, 200 cp --1 --
+!import-table-item --Occupations-Crawl --Halfling trader:melee|Short sword|1d6|1||:20 sp --1 --
+!import-table-item --Occupations-Crawl --Halfling vagrant:melee|Club|1d4|1||:Begging bowl --1 --
+!import-table-item --Occupations-Crawl --Healer:melee|Club|1d4|1||:Vial of holy water --1 --
+!import-table-item --Occupations-Crawl --Herbalist:melee|Club|1d4|1||:Herbs (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Herder:melee|Staff|1d4|1||:Herding dog --1 --
+!import-table-item --Occupations-Crawl --Hunter:ranged|Shortbow|1d6|2|50/100/150|Normal:Deer pelt --2 --
+!import-table-item --Occupations-Crawl --Indentured servant:melee|Staff|1d4|1||:Locket --1 --
+!import-table-item --Occupations-Crawl --Jester:ranged|Dart|1d4|1|20/40/60|Thrown:Silk clothes --1 --
+!import-table-item --Occupations-Crawl --Jeweler:both|Dagger|1d4|1|10/20/30|Thrown:Gem worth 20 gp --1 --
+!import-table-item --Occupations-Crawl --Locksmith:both|Dagger|1d4|1|10/20/30|Thrown:Fine tools --1 --
+!import-table-item --Occupations-Crawl --Mendicant:melee|Club|1d4|1||:Cheese dip --1 --
+!import-table-item --Occupations-Crawl --Mercenary:melee|Longsword|1d8|1||:Hide armor (+3 AC, -3 Check, d12 Fumble) --1 --
+!import-table-item --Occupations-Crawl --Merchant:both|Dagger|1d4|1|10/20/30|Thrown:4gp, 14 sp, 27 cp --1 --
+!import-table-item --Occupations-Crawl --Miller/baker:melee|Club|1d4|1||:Flour (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Minstrel:both|Dagger|1d4|1|10/20/30|Thrown:Ukulele --1 --
+!import-table-item --Occupations-Crawl --Noble:melee|Longsword|1d8|1||:Gold ring worth 10 gp --1 --
+!import-table-item --Occupations-Crawl --Orphan:melee|Club|1d4|1||:Rag doll --1 --
+!import-table-item --Occupations-Crawl --Ostler:melee|Staff|1d4|1||:Bridle --1 --
+!import-table-item --Occupations-Crawl --Outlaw:melee|Short sword|1d6|1||:Leather armor (AC +2, -1 Check, d8 Fumble) --1 --
+!import-table-item --Occupations-Crawl --Rope maker:both|Knife|1d4|1|10/20/30|Thrown:Rope (100') --1 --
+!import-table-item --Occupations-Crawl --Scribe:ranged|Dart|1d4|1|20/40/60|Thrown:Parchment (10 sheets) --1 --
+!import-table-item --Occupations-Crawl --Shaman:melee|Mace|1d6|1||:Herbs (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Slave:melee|Club|1d4|1||:Strange-looking rock --1 --
+!import-table-item --Occupations-Crawl --Smuggler:ranged|Sling|1d4|1|40/80/160|Thrown:Waterproof sack --1 --
+!import-table-item --Occupations-Crawl --Soldier:melee|Spear|1d8|1||:Shield (AC +1, Check -1) --1 --
+!import-table-item --Occupations-Crawl --Squire:melee|Longsword|1d8|1||:Steel helmet --2 --
+!import-table-item --Occupations-Crawl --Tax collector:melee|Longsword|1d8|1||:100 cp --1 --
+!import-table-item --Occupations-Crawl --Trapper:ranged|Sling|1d4|1|40/80/160|Thrown:Badger pelt --2 --
+!import-table-item --Occupations-Crawl --Urchin:melee|Stick|1d4|1||:Begging bowl --1 --
+!import-table-item --Occupations-Crawl --Wainwright:melee|Club|1d4|1||:Pushcart --1 --
+!import-table-item --Occupations-Crawl --Weaver:both|Dagger|1d4|1|10/20/30|Thrown:Fine suit of clothes --1 --
+!import-table-item --Occupations-Crawl --Wizard's apprentice:both|Dagger|1d4|1|10/20/30|Thrown:Black grimoire --1 --
+!import-table-item --Occupations-Crawl --Woodcutter:both|Handaxe|1d6|1|10/20/30|Thrown:Bundle of wood --3 --
+!import-table-item --Occupations-Crawl --Gnome gardener:both|Hand garden fork|1d4|1|10/20/30|Thrown:Bag of flower weeds, green thumbs --1 --
+!import-table-item --Occupations-Crawl --Gnome entertainer:melee|Black wand|1d4|1||:Shiny black top hat, white gloves --1 --
+!import-table-item --Occupations-Crawl --Gnome stroller:melee|Walking stick|1d4|1||:Pants with large pockets (holding small rocks, thread) --1 --
+!import-table --Races-CUaBM --hide
+!import-table-item --Races-CUaBM --Human --60 --
+!import-table-item --Races-CUaBM --Dwarf --6 --
+!import-table-item --Races-CUaBM --Elf --5 --
+!import-table-item --Races-CUaBM --Halfling --6 --
+!import-table-item --Races-CUaBM --Mutant --15 --
+!import-table-item --Races-CUaBM --Robot --1 --
+!import-table-item --Races-CUaBM --Morlock --5 --
+!import-table-item --Races-CUaBM --Reptilian --2 --

--- a/tables/individual/Birth-Augur-Lucky-Roll-Core.txt
+++ b/tables/individual/Birth-Augur-Lucky-Roll-Core.txt
@@ -1,31 +1,31 @@
 !import-table --Birth-Augur-Lucky-Roll-Core --show
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Harsh winter:All attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --The Bull:Melee attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Fortunate Date:Missile fire attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Raised by wolves:Unarmed attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Conceived on horseback:Mounted attack rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Born on the battlefield:Damage rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Path of the bear:Melee damage rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Hawkeye:Missile fire damage rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Pack hunter:Attack and damage rolls for 0-level starting weapon --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Born under the loom:Skill checks (including thief skills) --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Fox's cunning:Find / disable traps --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Four-leafed clover:Find secret doors --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Seventh son:Spell checks --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --The raging storm:Spell damage --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Righteous heart:Turn unholy checks --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Survived the plague:Magical Healing --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Lucky sign:Saving throws --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Guardian angel:Saving throws to escape traps --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Survived a spider bite:Saving throws against poison --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Struck by lightning:Reflex saving throws --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Lived through famine:Fortitude saving throws --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Resisted temptation:Willpower saving throws --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Charmed house:Armor class --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Speed of the cobra:Initiative --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Bountiful harvest:Hit points (applies at each level) --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Warrior's arm:Critical hit tables --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Unholy house:Corruption rolls --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --The Broken Star:Fumbles --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Birdsong:Number of languages --1 --
-!import-table-item --Birth-Augur-Lucky-Roll-Core --Wild child:Speed (each +1 / -1 = +5' / -5' speed) --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Harsh winter:All attack rolls:allAtkLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --The Bull:Melee attack rolls:meleeAtkLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Fortunate Date:Missile fire attack rolls:rangedAtkLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Raised by wolves:Unarmed attack rolls: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Conceived on horseback:Mounted attack rolls: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Born on the battlefield:Damage rolls:dmgLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Path of the bear:Melee damage rolls:meleeDmgLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Hawkeye:Missile fire damage rolls:rangedDmgLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Pack hunter:Attack and damage rolls for 0-level starting weapon:special_zeroWeaponLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Born under the loom:Skill checks (including thief skills):skillChecksLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Fox's cunning:Find / disable traps:findDisableTrapsLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Four-leafed clover:Find secret doors:findSecretDoorsLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Seventh son:Spell checks:spellCastLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --The raging storm:Spell damage: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Righteous heart:Turn unholy checks:turnUnholyLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Survived the plague:Magical Healing:layOnHandsLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Lucky sign:Saving throws:savingThrowsLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Guardian angel:Saving throws to escape traps: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Survived a spider bite:Saving throws against poison: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Struck by lightning:Reflex saving throws:reflexLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Lived through famine:Fortitude saving throws:fortitudeLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Resisted temptation:Willpower saving throws:willLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Charmed house:Armor class:armorClassLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Speed of the cobra:Initiative:initLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Bountiful harvest:Hit points (applies at each level):hpLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Warrior's arm:Critical hit tables:critLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Unholy house:Corruption rolls:corruptionLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --The Broken Star:Fumbles:fumbleLuckyRoll --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Birdsong:Number of languages: --1 --
+!import-table-item --Birth-Augur-Lucky-Roll-Core --Wild child:Speed (each +1 / -1 = +5' / -5' speed):speedLuckyRoll --1 --

--- a/tables/individual/Equipment-CUaBM.txt
+++ b/tables/individual/Equipment-CUaBM.txt
@@ -1,4 +1,4 @@
-!import-table --Equipment-CUaBM --hide
+!import-table --Equipment-CUaBM --show
 !import-table-item --Equipment-CUaBM --3 Plasticware Containers --1 --
 !import-table-item --Equipment-CUaBM --4 Firestarter Bricks --1 --
 !import-table-item --Equipment-CUaBM --20 Resealable Plastic Bags --1 --
@@ -32,7 +32,7 @@
 !import-table-item --Equipment-CUaBM --Metal Tongs --1 --
 !import-table-item --Equipment-CUaBM --Mirror, Hand-sized --1 --
 !import-table-item --Equipment-CUaBM --Nylon Rope, 50' --1 --
-!import-table-item --Equipment-CUaBM --Oil, 1 flask* --1 --
+!import-table-item --Equipment-CUaBM --Oil, 1 flask --1 --
 !import-table-item --Equipment-CUaBM --Pocket Fisherman --1 --
 !import-table-item --Equipment-CUaBM --Poker Set with Chips --1 --
 !import-table-item --Equipment-CUaBM --Pole, 10' --1 --

--- a/tables/individual/Equipment-Core.txt
+++ b/tables/individual/Equipment-Core.txt
@@ -11,15 +11,15 @@
 !import-table-item --Equipment-Core --Hammer, small --1 --
 !import-table-item --Equipment-Core --Holy symbol --1 --
 !import-table-item --Equipment-Core --Holy water, 1 vial --1 --
-!import-table-item --Equipment-Core --Iron spikes (1d3) --1 --
+!import-table-item --Equipment-Core --Iron spike --1 --
 !import-table-item --Equipment-Core --Lantern --1 --
 !import-table-item --Equipment-Core --Mirror, hand-sized --1 --
 !import-table-item --Equipment-Core --Oil, 1 flask --1 --
 !import-table-item --Equipment-Core --Pole, 10' --1 --
-!import-table-item --Equipment-Core --Rations (1d3 days) --1 --
+!import-table-item --Equipment-Core --Rations, 1 day --1 --
 !import-table-item --Equipment-Core --Rope, 50' --1 --
 !import-table-item --Equipment-Core --Sack, large --1 --
 !import-table-item --Equipment-Core --Sack, small --1 --
 !import-table-item --Equipment-Core --Thieves' tools --1 --
-!import-table-item --Equipment-Core --Torch (1d3) --1 --
+!import-table-item --Equipment-Core --Torch --1 --
 !import-table-item --Equipment-Core --Waterskin --1 --

--- a/tables/individual/Farm-Animals-Core.txt
+++ b/tables/individual/Farm-Animals-Core.txt
@@ -1,0 +1,10 @@
+!import-table --Farm-Animals-Core --show
+!import-table-item --Farm-Animals-Core --Hen --1 --
+!import-table-item --Farm-Animals-Core --Sheep --1 --
+!import-table-item --Farm-Animals-Core --Goat --1 --
+!import-table-item --Farm-Animals-Core --Cow --1 --
+!import-table-item --Farm-Animals-Core --Duck --1 --
+!import-table-item --Farm-Animals-Core --Goose --1 --
+!import-table-item --Farm-Animals-Core --Mule --1 --
+!import-table-item --Farm-Animals-Core --Herding Dog --1 --
+!import-table-item --Farm-Animals-Core --Sow --1 --

--- a/tables/individual/Farmer-Core.txt
+++ b/tables/individual/Farmer-Core.txt
@@ -1,0 +1,9 @@
+!import-table --Farmer-Core --show
+!import-table-item --Farmer-Core --Potato Farmer --1 --
+!import-table-item --Farmer-Core --Wheat Farmer --1 --
+!import-table-item --Farmer-Core --Turnip Farmer --1 --
+!import-table-item --Farmer-Core --Corn Farmer --1 --
+!import-table-item --Farmer-Core --Rice Farmer --1 --
+!import-table-item --Farmer-Core --Parsnip Farmer --1 --
+!import-table-item --Farmer-Core --Radish Farmer --1 --
+!import-table-item --Farmer-Core --Rutabega Farmer --1 --

--- a/tables/individual/Occupations-CUaBM.txt
+++ b/tables/individual/Occupations-CUaBM.txt
@@ -1,31 +1,31 @@
-!import-table --Occupations-CUaBM --hide
-!import-table-item --Occupations-CUaBM --Accountant:Big Ledger (1d3):Solar calculator --1 --
-!import-table-item --Occupations-CUaBM --Armorer:Sledge Hammer (1d7, 2-handed):Retread armor (as studded) --1 --
-!import-table-item --Occupations-CUaBM --Biker:Length of Chain (1d5):Leather Jacket (as Leather) --1 --
-!import-table-item --Occupations-CUaBM --Brewer:Bung Hammer (1d4):1d3 gallons of booze --1 --
-!import-table-item --Occupations-CUaBM --Carpenter:Claw Hammer (1d5):Bag of 2d30 nails --1 --
-!import-table-item --Occupations-CUaBM --Chemist:1d6 vials of mild acid (1d4):1d3 Molotove cocktails (Era 3) --1 --
-!import-table-item --Occupations-CUaBM --Cook:Cleaver (1d5):3d4 trial rations --1 --
-!import-table-item --Occupations-CUaBM --Electrician:Screwdriver (1d3):Bag of wires and bits --1 --
-!import-table-item --Occupations-CUaBM --Farmer:Hoe (1d5):1 Farm animal --1 --
-!import-table-item --Occupations-CUaBM --Ganger:Slingshot and bag of bearings (1d4):1 bottle of good booze --1 --
-!import-table-item --Occupations-CUaBM --Guard:Spear (1d6):Leather armor --1 --
-!import-table-item --Occupations-CUaBM --Gunsmith:rebuilt revolver (1d6, range 50ft):3d4 good bullets --1 --
-!import-table-item --Occupations-CUaBM --Handyman:Large tool (1d4):Tool belt with 1d3+1 tools --1 --
-!import-table-item --Occupations-CUaBM --Historian:Heavy book (1d3):Trivia (+3 to checks) --1 --
-!import-table-item --Occupations-CUaBM --Janitor:Large mop (1d3):5 gal bucket and rags --1 --
-!import-table-item --Occupations-CUaBM --Livestock Rancher:Crook staff (1d5):1d3 Farm animals --1 --
-!import-table-item --Occupations-CUaBM --Mechanic:Tire iron (1d6):1d3 gallons of used oil --1 --
-!import-table-item --Occupations-CUaBM --Medic:Scalpel (1d4):First aid kit --1 --
-!import-table-item --Occupations-CUaBM --Merchant:Big Maglite (1d4) (batteries charged):1d3 rolls on Equipment table --1 --
-!import-table-item --Occupations-CUaBM --Miner:Pickaxe (1d5):Filtered mask --1 --
-!import-table-item --Occupations-CUaBM --Nurse:Scalpel (1d4):Stethoscope --1 --
-!import-table-item --Occupations-CUaBM --Peddler:Iron skillet (1d5):1d3 rolls on Equipment table --1 --
-!import-table-item --Occupations-CUaBM --Pharmacist:Knife (1d3):2d3 bottles of drugs --1 --
-!import-table-item --Occupations-CUaBM --Plumber:Wrench (1d4):2d3 copper pipes --1 --
-!import-table-item --Occupations-CUaBM --Researcher:Heavy book (1d3):1d6 more books --1 --
-!import-table-item --Occupations-CUaBM --Scavenger:Crowbar (1d6):1d3 rolls on Equipment table --1 --
-!import-table-item --Occupations-CUaBM --Scientist:Bunsen burner & propane tank (1d3):rubber gloves and goggles --1 --
-!import-table-item --Occupations-CUaBM --Scout:Crossbow and 3d4 bolts:Compass --1 --
-!import-table-item --Occupations-CUaBM --Soldier:Bolt action rifle w/bayonet (1d10, 120ft) (Bayonet 1d6):2d4 bullets --1 --
-!import-table-item --Occupations-CUaBM --Wanderer:big walking stick (1d5):Large backpack --1 --
+!import-table --Occupations-CUaBM --show
+!import-table-item --Occupations-CUaBM --Accountant:melee|Big Ledger|1d3|1||:Solar calculator --1 --
+!import-table-item --Occupations-CUaBM --Armorer:melee|Sledge Hammer|1d7|2||:Retread armor (as studded) --1 --
+!import-table-item --Occupations-CUaBM --Biker:melee|Length of Chain|1d5|1||:Leather Jacket (as Leather) --1 --
+!import-table-item --Occupations-CUaBM --Brewer:melee|Bung Hammer|1d4|1||:1d3 gallons of booze --1 --
+!import-table-item --Occupations-CUaBM --Carpenter:melee|Claw Hammer|1d5|1||:Bag of 2d30 nails --1 --
+!import-table-item --Occupations-CUaBM --Chemist:ranged|Vial of mild acid|1d4|1|10/20/30|Normal:1d3 Molotove cocktails (Era 3) --1 --
+!import-table-item --Occupations-CUaBM --Cook:melee|Cleaver|1d5|1||:3d4 trial rations --1 --
+!import-table-item --Occupations-CUaBM --Electrician:melee|Screwdriver|1d3|1||:Bag of wires and bits --1 --
+!import-table-item --Occupations-CUaBM --Farmer:melee|Hoe|1d5|1||:1 Farm animal --1 --
+!import-table-item --Occupations-CUaBM --Ganger:ranged|Slingshot and bag of bearings|1d4|1|40/80/160|Normal:1 bottle of good booze --1 --
+!import-table-item --Occupations-CUaBM --Guard:melee|Spear|1d6|1||:Leather armor --1 --
+!import-table-item --Occupations-CUaBM --Gunsmith:ranged|Rebuilt revolver|1d6|1|50/100/150|Normal:3d4 good bullets --1 --
+!import-table-item --Occupations-CUaBM --Handyman:melee|Large tool|1d4|1||:Tool belt with 1d3+1 tools --1 --
+!import-table-item --Occupations-CUaBM --Historian:melee|Heavy book|1d3|1||:Trivia (+3 to checks) --1 --
+!import-table-item --Occupations-CUaBM --Janitor:melee|Large mop|1d3|1||:5 gal bucket and rags --1 --
+!import-table-item --Occupations-CUaBM --Livestock Rancher:melee|Crook staff|1d5|1||:1d3 Farm animals --1 --
+!import-table-item --Occupations-CUaBM --Mechanic:melee|Tire iron|1d6|1||:1d3 gallons of used oil --1 --
+!import-table-item --Occupations-CUaBM --Medic:melee|Scalpel|1d4|1||:First aid kit --1 --
+!import-table-item --Occupations-CUaBM --Merchant:melee|Big Maglite (batteries charged)|1d4|1||:1d3 rolls on Equipment table --1 --
+!import-table-item --Occupations-CUaBM --Miner:melee|Pickaxe|1d5|1||:Filtered mask --1 --
+!import-table-item --Occupations-CUaBM --Nurse:melee|Scalpel|1d4|1||:Stethoscope --1 --
+!import-table-item --Occupations-CUaBM --Peddler:melee|Iron skillet|1d5|1||:1d3 rolls on Equipment table --1 --
+!import-table-item --Occupations-CUaBM --Pharmacist:both|Knife|1d3|1|10/20/30|Thrown:2d3 bottles of drugs --1 --
+!import-table-item --Occupations-CUaBM --Plumber:melee|Wrench|1d4|1||:2d3 copper pipes --1 --
+!import-table-item --Occupations-CUaBM --Researcher:melee|Heavy book|1d3|1||:1d6 more books --1 --
+!import-table-item --Occupations-CUaBM --Scavenger:melee|Crowbar|1d6|1||:1d3 rolls on Equipment table --1 --
+!import-table-item --Occupations-CUaBM --Scientist:melee|Bunsen burner & propane tank|1d3|1||:rubber gloves and goggles --1 --
+!import-table-item --Occupations-CUaBM --Scout:ranged|Crossbow and 3d4 bolts|1d6|1|80/160/240|Normal:Compass --1 --
+!import-table-item --Occupations-CUaBM --Soldier:ranged|Bolt action rifle w/bayonet (bayonet 1d6)|1d10|1|120/240/360|Normal:2d4 bullets --1 --
+!import-table-item --Occupations-CUaBM --Wanderer:melee|Big walking stick|1d5|1||:Large backpack --1 --

--- a/tables/individual/Occupations-Core.txt
+++ b/tables/individual/Occupations-Core.txt
@@ -1,80 +1,81 @@
 !import-table --Occupations-Core --show
-!import-table-item --Occupations-Core --Alchemist:Melee|Staff|1d4|Blunt|1:Flask of oil --1 --
-!import-table-item --Occupations-Core --Animal trainer:Melee|Club|1d4|Blunt|1:Pony --1 --
-!import-table-item --Occupations-Core --Armorer:Melee|Hammer|1d4|Blunt|1:Iron helmet --1 --
-!import-table-item --Occupations-Core --Astrologer:Melee|Dagger|1d4|Piercing|1:Spyglass --1 --
-!import-table-item --Occupations-Core --Barber:Melee|Razor|1d4|Piercing|1:Scissors --1 --
-!import-table-item --Occupations-Core --Beadle:Melee|Staff|1d4|Blunt|1:Holy symbol --1 --
-!import-table-item --Occupations-Core --Beekeeper:Melee|Staff|1d4|Blunt|1:Jar of honey --1 --
-!import-table-item --Occupations-Core --Blacksmith:Melee|Hammer|1d4|Blunt|1:Steel tongs --1 --
-!import-table-item --Occupations-Core --Butcher:Melee|Cleaver|1d6|Slashing|1:Side of beef --1 --
-!import-table-item --Occupations-Core --Caravan guard:Melee|Short sword|1d6|Slashing|1:Linen (1 yard) --1 --
-!import-table-item --Occupations-Core --Cheesemaker:Melee|Cudgel|1d4|Blunt|1:Stinky cheese --1 --
-!import-table-item --Occupations-Core --Cobbler:Melee|Awl|1d4|Piercing|1:Shoehorn --1 --
-!import-table-item --Occupations-Core --Confidence artist:Melee|Dagger|1d4|Piercing|1:Quality cloak --1 --
-!import-table-item --Occupations-Core --Cooper:Melee|Crowbar|1d4|Blunt|1:Barrel --1 --
-!import-table-item --Occupations-Core --Costermonger:Melee|Knife|1d4|Piercing|1:Fruit --1 --
-!import-table-item --Occupations-Core --Cupurse:Melee|Dagger|1d4|Piercing|1:Small chest --1 --
-!import-table-item --Occupations-Core --Ditch digger:Melee|Shovel|1d4|Blunt|1:Fine dirt (1 lb.) --1 --
-!import-table-item --Occupations-Core --Dwarven Apothecarist:Melee|Cudgel|1d4|Blunt|1:Steel vial --1 --
-!import-table-item --Occupations-Core --Dwarven blacksmith:Melee|Hammer|1d4|Blunt|1:Mithril (1 oz.) --2 --
-!import-table-item --Occupations-Core --Dwarven chest-maker:Melee|Chisel|1d4|Piercing|1:Wood (10 lbs.) --1 --
-!import-table-item --Occupations-Core --Dwarven herder:Melee|Staff|1d4|Blunt|1:Sow --1 --
-!import-table-item --Occupations-Core --Dwarven miner:Melee|Pick|1d4|Piercing|1:Lantern --2 --
-!import-table-item --Occupations-Core --Dwarven mushroom farmer:Melee|Shovel|1d4|Blunt|1:Sack --1 --
-!import-table-item --Occupations-Core --Dwarven rat-catcher:Melee|Club|1d4|Blunt|1:Net --1 --
-!import-table-item --Occupations-Core --Dwarven stonemason:Melee|Hammer|1d4|Blunt|1:Fine stone (10 lbs.) --2 --
-!import-table-item --Occupations-Core --Elven artisan:Mele|Staff|1d4|Blunt|1:Clay (1 lb.) --1 --
-!import-table-item --Occupations-Core --Elven barrister:Melee|Quill|1d4|Piercing|1:Book --1 --
-!import-table-item --Occupations-Core --Elven chandler:Melee|Scissors|1d4|Piercing|1:Candles (20) --1 --
-!import-table-item --Occupations-Core --Elven falconer:Melee|Dagger|1d4|Piercing|1:Falcon --1 --
-!import-table-item --Occupations-Core --Elven Forester:Melee|Staff|1d4|Blunt|1:Herbs (1 lb.) --2 --
-!import-table-item --Occupations-Core --Elven Glassblower:Melee|Hammer|1d4|Blunt|1:Glass beads --1 --
-!import-table-item --Occupations-Core --Elven navigator:Ranged|Short bow|1d6|Piercing|2|50/100/150|Normal:Spyglass --1 --
-!import-table-item --Occupations-Core --Elven sage:Melee|Dagger|1d4|Piercing|1:Parchment, quill --2 --
-!import-table-item --Occupations-Core --Farmer:Melee|Pitchfork|1d8|Piercing|1:Hen --8 --
-!import-table-item --Occupations-Core --Fortune-teller:Melee|Dagger|1d4|Piercing|1:Tarot deck --1 --
-!import-table-item --Occupations-Core --Gambler:Melee|Club|1d4|Blunt|1:Dice --1 --
-!import-table-item --Occupations-Core --Gongfarmer:Melee|Trowel|1d4|Slashing|1:Sack of night soil --1 --
-!import-table-item --Occupations-Core --Grave digger:Melee|Shovel|1d8|Blunt|1:Trowel --2 --
-!import-table-item --Occupations-Core --Guild beggar:Ranged|Sling|1d4|Blunt|1|40/80/160|Thrown:Crutches --2 --
-!import-table-item --Occupations-Core --Halfling chicken butcher:Melee|Hand axe|1d6|Slashing|1:Chicken meat (5 lbs.) --1 --
-!import-table-item --Occupations-Core --Halfling dyer:Melee|Staff|1d4|Blunt|1:Fabric (3 yards) --2 --
-!import-table-item --Occupations-Core --Halfling glovemaker:Melee|Awl|1d4|Piercing|1:Gloves (4 pairs) --1 --
-!import-table-item --Occupations-Core --Halfling gypsy:Ranged|Sling|1d4|1|40/80/160|Thrown:Hex doll --1 --
-!import-table-item --Occupations-Core --Halfling haberdasher:Melee|Scissors|1d4|Piercing|1:Fine suits (3 sets) --1 --
-!import-table-item --Occupations-Core --Halfling mariner:Melee|Knife|1d4|Piercing|1:Sailcloth (2 yards) --1 --
-!import-table-item --Occupations-Core --Halfling moneylender:Melee|Short sword|1d6|Slashing|1:5 gp, 10 sp, 200 cp --1 --
-!import-table-item --Occupations-Core --Halfling trader:Melee|Short sword|1d6|Slashing|1:20 sp --1 --
-!import-table-item --Occupations-Core --Halfling vagrant:Melee|Club|1d6|Blunt|1:Begging bowl --1 --
-!import-table-item --Occupations-Core --Healer:Melee|Club|1d4|Blunt|1:Vial of holy water --1 --
-!import-table-item --Occupations-Core --Herbalist:Melee|Club|1d4|Blunt|1:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Core --Herder:Melee|Staff|1d8|Blunt|1:Herding dog --1 --
-!import-table-item --Occupations-Core --Hunter:Ranged|Short bow|1d6|Piercing|50/100/150|Normal:Deer pelt --2 --
-!import-table-item --Occupations-Core --Indentured servant:Melee|Staff|1d8|Blunt|1:Locket --1 --
-!import-table-item --Occupations-Core --Jester:Ranged|Dart|1d4|Piercing|1|20/40/60|Thrown:Silk clothes --1 --
-!import-table-item --Occupations-Core --Jeweler:Melee|Dagger|1d4|Piercing|1:Gem worth 20 gp --1 --
-!import-table-item --Occupations-Core --Locksmith:Melee|Dagger|1d4|Piercing|1:Fine tools --1 --
-!import-table-item --Occupations-Core --Mendicant:Melee|Club|1d4|Blunt|1:Cheese dip --1 --
-!import-table-item --Occupations-Core --Mercenary:Melee|Longsword|1d8|Slashing|1:Hide armor (+3 AC, -3 Check, d12 Fumble) --1 --
-!import-table-item --Occupations-Core --Merchant:Melee|Dagger|1d4|Piercing|1:4gp, 14 sp, 27 cp --1 --
-!import-table-item --Occupations-Core --Miller/baker:Melee|Club|1d4|Blunt|1:Flour (1 lb.) --1 --
-!import-table-item --Occupations-Core --Minstrel:Melee|Dagger|1d4|Piercing|1:Ukulele --1 --
-!import-table-item --Occupations-Core --Noble:Melee|Longsword|1d8|Slashing|1:Gold ring worth 10 gp --1 --
-!import-table-item --Occupations-Core --Orphan:Melee|Club|1d4|Blunt|1:Rag doll --1 --
-!import-table-item --Occupations-Core --Ostler:Melee|Staff|1d4|Blunt|1:Bridle --1 --
-!import-table-item --Occupations-Core --Outlaw:Melee|Short sword|1d6|Slashing|1:Leather armor (AC +2, -1 Check, d8 Fumble) --1 --
-!import-table-item --Occupations-Core --Rope maker:Melee|Knife|1d4|Piercing|1:Rope (100') --1 --
-!import-table-item --Occupations-Core --Scribe:Ranged|Dart|1d4|Piercing|1|20/40/60|Thrown:Parchment (10 sheets) --1 --
-!import-table-item --Occupations-Core --Shaman:Melee|Mace|1d6|Blunt|1:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Core --Slave:Melee|Club|1d4|Blunt|1:Strange-looking rock --1 --
-!import-table-item --Occupations-Core --Smuggler:Ranged|Sling|1d4|Blunt|40/80/160|Thrown:Waterproof sack --1 --
-!import-table-item --Occupations-Core --Soldier:Melee|Spear|1d8|Piercing|1:Shield (AC +1, Check -1) --1 --
-!import-table-item --Occupations-Core --Squire:Melee|Longsword|1d8|Slashing|1:Steel helmet --2 --
-!import-table-item --Occupations-Core --Tax collector:Melee|Longsword|1d8|Slashing|1:100 cp --1 --
-!import-table-item --Occupations-Core --Trapper:Ranged|Sling|1d4|Blunt|1|40/80/160|Thrown:Badger pelt --2 --
-!import-table-item --Occupations-Core --Urchin:Melee|Stick|1d4|Blunt|1:Begging bowl --1 --
-!import-table-item --Occupations-Core --Wainwright:Melee|Club|1d4|Blunt|1:Pushcart --1 --
-!import-table-item --Occupations-Core --Weaver:Melee|Dagger|1d4|Piercing|1:Fine suit of clothes --1 --
-!import-table-item --Occupations-Core --Wizard's apprentice:Melee|Dagger|1d4|Piercing|1:Black grimoire --1 --
-!import-table-item --Occupations-Core --Woodcutter:Melee|Handaxe|1d6|Slashing|1:Bundle of wood --2 --
+!import-table-item --Occupations-Core --Alchemist:melee|Staff|1d4|1||:Flask of oil --1 --
+!import-table-item --Occupations-Core --Animal trainer:melee|Club|1d4|1||:Pony --1 --
+!import-table-item --Occupations-Core --Armorer:melee|Hammer|1d4|1||:Iron helmet --1 --
+!import-table-item --Occupations-Core --Astrologer:both|Dagger|1d4|1|10/20/30|Thrown:Spyglass --1 --
+!import-table-item --Occupations-Core --Barber:both|Razor|1d4|1|10/20/30|Thrown:Scissors --1 --
+!import-table-item --Occupations-Core --Beadle:melee|Staff|1d4|1||:Holy symbol --1 --
+!import-table-item --Occupations-Core --Beekeeper:melee|Staff|1d4|1||:Jar of honey --1 --
+!import-table-item --Occupations-Core --Blacksmith:melee|Hammer|1d4|1||:Steel tongs --1 --
+!import-table-item --Occupations-Core --Butcher:both|Cleaver|1d6|1|10/20/30|Thrown:Side of beef --1 --
+!import-table-item --Occupations-Core --Caravan guard:melee|Short sword|1d6|1||:Linen (1 yard) --1 --
+!import-table-item --Occupations-Core --Cheesemaker:melee|Cudgel|1d4|1||:Stinky cheese --1 --
+!import-table-item --Occupations-Core --Cobbler:both|Awl|1d4|1|10/20/30|Thrown:Shoehorn --1 --
+!import-table-item --Occupations-Core --Confidence artist:both|Dagger|1d4|1|10/20/30|Thrown:Quality cloak --1 --
+!import-table-item --Occupations-Core --Cooper:melee|Crowbar|1d4|1||:Barrel --1 --
+!import-table-item --Occupations-Core --Costermonger:both|Knife|1d4|1|10/20/30|Thrown:Fruit --1 --
+!import-table-item --Occupations-Core --Cutpurse:both|Dagger|1d4|1|10/20/30|Thrown:Small chest --1 --
+!import-table-item --Occupations-Core --Ditch digger:melee|Shovel|1d4|1||:Fine dirt (1 lb.) --1 --
+!import-table-item --Occupations-Core --Dock worker:melee|Pole|1d4|1||:1 late RPG book --1 --
+!import-table-item --Occupations-Core --Dwarven apothecarist:melee|Cudgel|1d4|1||:Steel vial --1 --
+!import-table-item --Occupations-Core --Dwarven blacksmith:melee|Hammer|1d4|1||:Mithril (1 oz.) --1 --
+!import-table-item --Occupations-Core --Dwarven chest-maker:both|Chisel|1d4|1|10/20/30|Thrown:Wood (10 lbs.) --1 --
+!import-table-item --Occupations-Core --Dwarven herder:melee|Staff|1d4|1||:Sow --1 --
+!import-table-item --Occupations-Core --Dwarven miner:melee|Pick|1d4|1||:Lantern --2 --
+!import-table-item --Occupations-Core --Dwarven mushroom-farmer:melee|Shovel|1d4|1||:Sack --1 --
+!import-table-item --Occupations-Core --Dwarven rat-catcher:melee|Club|1d4|1||:Net --1 --
+!import-table-item --Occupations-Core --Dwarven stonemason:melee|Hammer|1d4|1||:Fine stone (10 lbs.) --2 --
+!import-table-item --Occupations-Core --Elven artisan:melee|Staff|1d4|1||:Clay (1 lb.) --1 --
+!import-table-item --Occupations-Core --Elven barrister:ranged|Quill|1d4|1|20/40/60|Thrown:Book --1 --
+!import-table-item --Occupations-Core --Elven chandler:both|Scissors|1d4|1|10/20/30|Thrown:Candles (20) --1 --
+!import-table-item --Occupations-Core --Elven falconer:both|Dagger|1d4|1|10/20/30|Thrown:Falcon --1 --
+!import-table-item --Occupations-Core --Elven forester:melee|Staff|1d4|1||:Herbs (1 lb.) --2 --
+!import-table-item --Occupations-Core --Elven glassblower:melee|Hammer|1d4|1||:Glass beads --1 --
+!import-table-item --Occupations-Core --Elven navigator:ranged|Shortbow|1d6|2|50/100/150|Normal:Spyglass --1 --
+!import-table-item --Occupations-Core --Elven sage:both|Dagger|1d4|1|10/20/30|Thrown:Parchment, quill --2 --
+!import-table-item --Occupations-Core --Farmer:melee|Pitchfork|1d8|1||:Hen --9 --
+!import-table-item --Occupations-Core --Fortune-teller:both|Dagger|1d4|1|10/20/30|Thrown:Tarot deck --1 --
+!import-table-item --Occupations-Core --Gambler:melee|Club|1d4|1||:Dice --1 --
+!import-table-item --Occupations-Core --Gongfarmer:both|Trowel|1d4|1|10/20/30|Thrown:Sack of night soil --1 --
+!import-table-item --Occupations-Core --Grave digger:melee|Shovel|1d4|1||:Trowel --2 --
+!import-table-item --Occupations-Core --Guild beggar:ranged|Sling|1d4|1|40/80/160|Thrown:Crutches --2 --
+!import-table-item --Occupations-Core --Halfling chicken butcher:both|Handaxe|1d6|1|10/20/30|Thrown:Chicken meat (5 lbs.) --1 --
+!import-table-item --Occupations-Core --Halfling dyer:melee|Staff|1d4|1||:Fabric (3 yards) --2 --
+!import-table-item --Occupations-Core --Halfling glovemaker:both|Awl|1d4|1|10/20/30|Thrown:Gloves (4 pairs) --1 --
+!import-table-item --Occupations-Core --Halfling gypsy:ranged|Sling|1d4|1|40/80/160|Thrown:Hex doll --1 --
+!import-table-item --Occupations-Core --Halfling haberdasher:both|Scissors|1d4|1|10/20/30|Thrown:Fine suits (3 sets) --1 --
+!import-table-item --Occupations-Core --Halfling mariner:both|Knife|1d4|1|10/20/30|Thrown:Sailcloth (2 yards) --1 --
+!import-table-item --Occupations-Core --Halfling moneylender:melee|Short sword|1d6|1||:5 gp, 10 sp, 200 cp --1 --
+!import-table-item --Occupations-Core --Halfling trader:melee|Short sword|1d6|1||:20 sp --1 --
+!import-table-item --Occupations-Core --Halfling vagrant:melee|Club|1d4|1||:Begging bowl --1 --
+!import-table-item --Occupations-Core --Healer:melee|Club|1d4|1||:Vial of holy water --1 --
+!import-table-item --Occupations-Core --Herbalist:melee|Club|1d4|1||:Herbs (1 lb.) --1 --
+!import-table-item --Occupations-Core --Herder:melee|Staff|1d4|1||:Herding dog --1 --
+!import-table-item --Occupations-Core --Hunter:ranged|Shortbow|1d6|2|50/100/150|Normal:Deer pelt --2 --
+!import-table-item --Occupations-Core --Indentured servant:melee|Staff|1d4|1||:Locket --1 --
+!import-table-item --Occupations-Core --Jester:ranged|Dart|1d4|1|20/40/60|Thrown:Silk clothes --1 --
+!import-table-item --Occupations-Core --Jeweler:both|Dagger|1d4|1|10/20/30|Thrown:Gem worth 20 gp --1 --
+!import-table-item --Occupations-Core --Locksmith:both|Dagger|1d4|1|10/20/30|Thrown:Fine tools --1 --
+!import-table-item --Occupations-Core --Mendicant:melee|Club|1d4|1||:Cheese dip --1 --
+!import-table-item --Occupations-Core --Mercenary:melee|Longsword|1d8|1||:Hide armor (+3 AC, -3 Check, d12 Fumble) --1 --
+!import-table-item --Occupations-Core --Merchant:both|Dagger|1d4|1|10/20/30|Thrown:4gp, 14 sp, 27 cp --1 --
+!import-table-item --Occupations-Core --Miller/baker:melee|Club|1d4|1||:Flour (1 lb.) --1 --
+!import-table-item --Occupations-Core --Minstrel:both|Dagger|1d4|1|10/20/30|Thrown:Ukulele --1 --
+!import-table-item --Occupations-Core --Noble:melee|Longsword|1d8|1||:Gold ring worth 10 gp --1 --
+!import-table-item --Occupations-Core --Orphan:melee|Club|1d4|1||:Rag doll --1 --
+!import-table-item --Occupations-Core --Ostler:melee|Staff|1d4|1||:Bridle --1 --
+!import-table-item --Occupations-Core --Outlaw:melee|Short sword|1d6|1||:Leather armor (AC +2, -1 Check, d8 Fumble) --1 --
+!import-table-item --Occupations-Core --Rope maker:both|Knife|1d4|1|10/20/30|Thrown:Rope (100') --1 --
+!import-table-item --Occupations-Core --Scribe:ranged|Dart|1d4|1|20/40/60|Thrown:Parchment (10 sheets) --1 --
+!import-table-item --Occupations-Core --Shaman:melee|Mace|1d6|1||:Herbs (1 lb.) --1 --
+!import-table-item --Occupations-Core --Slave:melee|Club|1d4|1||:Strange-looking rock --1 --
+!import-table-item --Occupations-Core --Smuggler:ranged|Sling|1d4|1|40/80/160|Thrown:Waterproof sack --1 --
+!import-table-item --Occupations-Core --Soldier:melee|Spear|1d8|1||:Shield (AC +1, Check -1) --1 --
+!import-table-item --Occupations-Core --Squire:melee|Longsword|1d8|1||:Steel helmet --2 --
+!import-table-item --Occupations-Core --Tax collector:melee|Longsword|1d8|1||:100 cp --1 --
+!import-table-item --Occupations-Core --Trapper:ranged|Sling|1d4|1|40/80/160|Thrown:Badger pelt --2 --
+!import-table-item --Occupations-Core --Urchin:melee|Stick|1d4|1||:Begging bowl --1 --
+!import-table-item --Occupations-Core --Wainwright:melee|Club|1d4|1||:Pushcart --1 --
+!import-table-item --Occupations-Core --Weaver:both|Dagger|1d4|1|10/20/30|Thrown:Fine suit of clothes --1 --
+!import-table-item --Occupations-Core --Wizard's apprentice:both|Dagger|1d4|1|10/20/30|Thrown:Black grimoire --1 --
+!import-table-item --Occupations-Core --Woodcutter:both|Handaxe|1d6|1|10/20/30|Thrown:Bundle of wood --3 --

--- a/tables/individual/Occupations-Core.txt
+++ b/tables/individual/Occupations-Core.txt
@@ -20,7 +20,7 @@
 !import-table-item --Occupations-Core --Dwarven apothecarist:melee|Cudgel|1d4|1||:Steel vial --1 --
 !import-table-item --Occupations-Core --Dwarven blacksmith:melee|Hammer|1d4|1||:Mithril (1 oz.) --1 --
 !import-table-item --Occupations-Core --Dwarven chest-maker:both|Chisel|1d4|1|10/20/30|Thrown:Wood (10 lbs.) --1 --
-!import-table-item --Occupations-Core --Dwarven herder:melee|Staff|1d4|1||:Sow --1 --
+!import-table-item --Occupations-Core --Dwarven herder:melee|Staff|1d4|1||:$subtable-Farm-Animals-Core --1 --
 !import-table-item --Occupations-Core --Dwarven miner:melee|Pick|1d4|1||:Lantern --2 --
 !import-table-item --Occupations-Core --Dwarven mushroom-farmer:melee|Shovel|1d4|1||:Sack --1 --
 !import-table-item --Occupations-Core --Dwarven rat-catcher:melee|Club|1d4|1||:Net --1 --
@@ -33,7 +33,7 @@
 !import-table-item --Occupations-Core --Elven glassblower:melee|Hammer|1d4|1||:Glass beads --1 --
 !import-table-item --Occupations-Core --Elven navigator:ranged|Shortbow|1d6|2|50/100/150|Normal:Spyglass --1 --
 !import-table-item --Occupations-Core --Elven sage:both|Dagger|1d4|1|10/20/30|Thrown:Parchment, quill --2 --
-!import-table-item --Occupations-Core --Farmer:melee|Pitchfork|1d8|1||:Hen --9 --
+!import-table-item --Occupations-Core --$subtable-Farmer-Core:melee|Pitchfork|1d8|1||:$subtable-Farm-Animals-Core --9 --
 !import-table-item --Occupations-Core --Fortune-teller:both|Dagger|1d4|1|10/20/30|Thrown:Tarot deck --1 --
 !import-table-item --Occupations-Core --Gambler:melee|Club|1d4|1||:Dice --1 --
 !import-table-item --Occupations-Core --Gongfarmer:both|Trowel|1d4|1|10/20/30|Thrown:Sack of night soil --1 --
@@ -50,7 +50,7 @@
 !import-table-item --Occupations-Core --Halfling vagrant:melee|Club|1d4|1||:Begging bowl --1 --
 !import-table-item --Occupations-Core --Healer:melee|Club|1d4|1||:Vial of holy water --1 --
 !import-table-item --Occupations-Core --Herbalist:melee|Club|1d4|1||:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Core --Herder:melee|Staff|1d4|1||:Herding dog --1 --
+!import-table-item --Occupations-Core --Herder:melee|Staff|1d4|1||:$subtable-Farm-Animals-Core --1 --
 !import-table-item --Occupations-Core --Hunter:ranged|Shortbow|1d6|2|50/100/150|Normal:Deer pelt --2 --
 !import-table-item --Occupations-Core --Indentured servant:melee|Staff|1d4|1||:Locket --1 --
 !import-table-item --Occupations-Core --Jester:ranged|Dart|1d4|1|20/40/60|Thrown:Silk clothes --1 --
@@ -75,7 +75,7 @@
 !import-table-item --Occupations-Core --Tax collector:melee|Longsword|1d8|1||:100 cp --1 --
 !import-table-item --Occupations-Core --Trapper:ranged|Sling|1d4|1|40/80/160|Thrown:Badger pelt --2 --
 !import-table-item --Occupations-Core --Urchin:melee|Stick|1d4|1||:Begging bowl --1 --
-!import-table-item --Occupations-Core --Wainwright:melee|Club|1d4|1||:Pushcart --1 --
+!import-table-item --Occupations-Core --Wainwright:melee|Club|1d4|1||:$subtable-Pushcart-Core --1 --
 !import-table-item --Occupations-Core --Weaver:both|Dagger|1d4|1|10/20/30|Thrown:Fine suit of clothes --1 --
 !import-table-item --Occupations-Core --Wizard's apprentice:both|Dagger|1d4|1|10/20/30|Thrown:Black grimoire --1 --
 !import-table-item --Occupations-Core --Woodcutter:both|Handaxe|1d6|1|10/20/30|Thrown:Bundle of wood --3 --

--- a/tables/individual/Occupations-Crawl.txt
+++ b/tables/individual/Occupations-Crawl.txt
@@ -1,83 +1,84 @@
 !import-table --Occupations-Crawl --show
-!import-table-item --Occupations-Crawl --Alchemist:Melee|Staff|1d4|Blunt|1:Flask of oil --1 --
-!import-table-item --Occupations-Crawl --Animal trainer:Melee|Club|1d4|Blunt|1:Pony --1 --
-!import-table-item --Occupations-Crawl --Armorer:Melee|Hammer|1d4|Blunt|1:Iron helmet --1 --
-!import-table-item --Occupations-Crawl --Astrologer:Melee|Dagger|1d4|Piercing|1:Spyglass --1 --
-!import-table-item --Occupations-Crawl --Barber:Melee|Razor|1d4|Piercing|1:Scissors --1 --
-!import-table-item --Occupations-Crawl --Beadle:Melee|Staff|1d4|Blunt|1:Holy symbol --1 --
-!import-table-item --Occupations-Crawl --Beekeeper:Melee|Staff|1d4|Blunt|1:Jar of honey --1 --
-!import-table-item --Occupations-Crawl --Blacksmith:Melee|Hammer|1d4|Blunt|1:Steel tongs --1 --
-!import-table-item --Occupations-Crawl --Butcher:Melee|Cleaver|1d6|Slashing|1:Side of beef --1 --
-!import-table-item --Occupations-Crawl --Caravan guard:Melee|Short sword|1d6|Slashing|1:Linen (1 yard) --1 --
-!import-table-item --Occupations-Crawl --Cheesemaker:Melee|Cudgel|1d4|Blunt|1:Stinky cheese --1 --
-!import-table-item --Occupations-Crawl --Cobbler:Melee|Awl|1d4|Piercing|1:Shoehorn --1 --
-!import-table-item --Occupations-Crawl --Confidence artist:Melee|Dagger|1d4|Piercing|1:Quality cloak --1 --
-!import-table-item --Occupations-Crawl --Cooper:Melee|Crowbar|1d4|Blunt|1:Barrel --1 --
-!import-table-item --Occupations-Crawl --Costermonger:Melee|Knife|1d4|Piercing|1:Fruit --1 --
-!import-table-item --Occupations-Crawl --Cupurse:Melee|Dagger|1d4|Piercing|1:Small chest --1 --
-!import-table-item --Occupations-Crawl --Ditch digger:Melee|Shovel|1d4|Blunt|1:Fine dirt (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Dwarven Apothecarist:Melee|Cudgel|1d4|Blunt|1:Steel vial --1 --
-!import-table-item --Occupations-Crawl --Dwarven blacksmith:Melee|Hammer|1d4|Blunt|1:Mithril (1 oz.) --2 --
-!import-table-item --Occupations-Crawl --Dwarven chest-maker:Melee|Chisel|1d4|Piercing|1:Wood (10 lbs.) --1 --
-!import-table-item --Occupations-Crawl --Dwarven herder:Melee|Staff|1d4|Blunt|1:Sow --1 --
-!import-table-item --Occupations-Crawl --Dwarven miner:Melee|Pick|1d4|Piercing|1:Lantern --2 --
-!import-table-item --Occupations-Crawl --Dwarven mushroom farmer:Melee|Shovel|1d4|Blunt|1:Sack --1 --
-!import-table-item --Occupations-Crawl --Dwarven rat-catcher:Melee|Club|1d4|Blunt|1:Net --1 --
-!import-table-item --Occupations-Crawl --Dwarven stonemason:Melee|Hammer|1d4|Blunt|1:Fine stone (10 lbs.) --2 --
-!import-table-item --Occupations-Crawl --Elven artisan:Mele|Staff|1d4|Blunt|1:Clay (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Elven barrister:Melee|Quill|1d4|Piercing|1:Book --1 --
-!import-table-item --Occupations-Crawl --Elven chandler:Melee|Scissors|1d4|Piercing|1:Candles (20) --1 --
-!import-table-item --Occupations-Crawl --Elven falconer:Melee|Dagger|1d4|Piercing|1:Falcon --1 --
-!import-table-item --Occupations-Crawl --Elven Forester:Melee|Staff|1d4|Blunt|1:Herbs (1 lb.) --2 --
-!import-table-item --Occupations-Crawl --Elven Glassblower:Melee|Hammer|1d4|Blunt|1:Glass beads --1 --
-!import-table-item --Occupations-Crawl --Elven navigator:Ranged|Short bow|1d6|Piercing|2|50/100/150|Normal:Spyglass --1 --
-!import-table-item --Occupations-Crawl --Elven sage:Melee|Dagger|1d4|Piercing|1:Parchment, quill --2 --
-!import-table-item --Occupations-Crawl --Farmer:Melee|Pitchfork|1d8|Piercing|1:Hen --8 --
-!import-table-item --Occupations-Crawl --Fortune-teller:Melee|Dagger|1d4|Piercing|1:Tarot deck --1 --
-!import-table-item --Occupations-Crawl --Gambler:Melee|Club|1d4|Blunt|1:Dice --1 --
-!import-table-item --Occupations-Crawl --Gongfarmer:Melee|Trowel|1d4|Slashing|1:Sack of night soil --1 --
-!import-table-item --Occupations-Crawl --Grave digger:Melee|Shovel|1d8|Blunt|1:Trowel --2 --
-!import-table-item --Occupations-Crawl --Guild beggar:Ranged|Sling|1d4|Blunt|1|40/80/160|Thrown:Crutches --2 --
-!import-table-item --Occupations-Crawl --Halfling chicken butcher:Melee|Hand axe|1d6|Slashing|1:Chicken meat (5 lbs.) --1 --
-!import-table-item --Occupations-Crawl --Halfling dyer:Melee|Staff|1d4|Blunt|1:Fabric (3 yards) --2 --
-!import-table-item --Occupations-Crawl --Halfling glovemaker:Melee|Awl|1d4|Piercing|1:Gloves (4 pairs) --1 --
-!import-table-item --Occupations-Crawl --Halfling gypsy:Ranged|Sling|1d4|1|40/80/160|Thrown:Hex doll --1 --
-!import-table-item --Occupations-Crawl --Halfling haberdasher:Melee|Scissors|1d4|Piercing|1:Fine suits (3 sets) --1 --
-!import-table-item --Occupations-Crawl --Halfling mariner:Melee|Knife|1d4|Piercing|1:Sailcloth (2 yards) --1 --
-!import-table-item --Occupations-Crawl --Halfling moneylender:Melee|Short sword|1d6|Slashing|1:5 gp, 10 sp, 200 cp --1 --
-!import-table-item --Occupations-Crawl --Halfling trader:Melee|Short sword|1d6|Slashing|1:20 sp --1 --
-!import-table-item --Occupations-Crawl --Halfling vagrant:Melee|Club|1d6|Blunt|1:Begging bowl --1 --
-!import-table-item --Occupations-Crawl --Healer:Melee|Club|1d4|Blunt|1:Vial of holy water --1 --
-!import-table-item --Occupations-Crawl --Herbalist:Melee|Club|1d4|Blunt|1:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Herder:Melee|Staff|1d8|Blunt|1:Herding dog --1 --
-!import-table-item --Occupations-Crawl --Hunter:Ranged|Short bow|1d6|Piercing|50/100/150|Normal:Deer pelt --2 --
-!import-table-item --Occupations-Crawl --Indentured servant:Melee|Staff|1d8|Blunt|1:Locket --1 --
-!import-table-item --Occupations-Crawl --Jester:Ranged|Dart|1d4|Piercing|1|20/40/60|Thrown:Silk clothes --1 --
-!import-table-item --Occupations-Crawl --Jeweler:Melee|Dagger|1d4|Piercing|1:Gem worth 20 gp --1 --
-!import-table-item --Occupations-Crawl --Locksmith:Melee|Dagger|1d4|Piercing|1:Fine tools --1 --
-!import-table-item --Occupations-Crawl --Mendicant:Melee|Club|1d4|Blunt|1:Cheese dip --1 --
-!import-table-item --Occupations-Crawl --Mercenary:Melee|Longsword|1d8|Slashing|1:Hide armor (+3 AC, -3 Check, d12 Fumble) --1 --
-!import-table-item --Occupations-Crawl --Merchant:Melee|Dagger|1d4|Piercing|1:4gp, 14 sp, 27 cp --1 --
-!import-table-item --Occupations-Crawl --Miller/baker:Melee|Club|1d4|Blunt|1:Flour (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Minstrel:Melee|Dagger|1d4|Piercing|1:Ukulele --1 --
-!import-table-item --Occupations-Crawl --Noble:Melee|Longsword|1d8|Slashing|1:Gold ring worth 10 gp --1 --
-!import-table-item --Occupations-Crawl --Orphan:Melee|Club|1d4|Blunt|1:Rag doll --1 --
-!import-table-item --Occupations-Crawl --Ostler:Melee|Staff|1d4|Blunt|1:Bridle --1 --
-!import-table-item --Occupations-Crawl --Outlaw:Melee|Short sword|1d6|Slashing|1:Leather armor (AC +2, -1 Check, d8 Fumble) --1 --
-!import-table-item --Occupations-Crawl --Rope maker:Melee|Knife|1d4|Piercing|1:Rope (100') --1 --
-!import-table-item --Occupations-Crawl --Scribe:Ranged|Dart|1d4|Piercing|1|20/40/60|Thrown:Parchment (10 sheets) --1 --
-!import-table-item --Occupations-Crawl --Shaman:Melee|Mace|1d6|Blunt|1:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Slave:Melee|Club|1d4|Blunt|1:Strange-looking rock --1 --
-!import-table-item --Occupations-Crawl --Smuggler:Ranged|Sling|1d4|Blunt|40/80/160|Thrown:Waterproof sack --1 --
-!import-table-item --Occupations-Crawl --Soldier:Melee|Spear|1d8|Piercing|1:Shield (AC +1, Check -1) --1 --
-!import-table-item --Occupations-Crawl --Squire:Melee|Longsword|1d8|Slashing|1:Steel helmet --2 --
-!import-table-item --Occupations-Crawl --Tax collector:Melee|Longsword|1d8|Slashing|1:100 cp --1 --
-!import-table-item --Occupations-Crawl --Trapper:Ranged|Sling|1d4|Blunt|1|40/80/160|Thrown:Badger pelt --2 --
-!import-table-item --Occupations-Crawl --Urchin:Melee|Stick|1d4|Blunt|1:Begging bowl --1 --
-!import-table-item --Occupations-Crawl --Wainwright:Melee|Club|1d4|Blunt|1:Pushcart --1 --
-!import-table-item --Occupations-Crawl --Weaver:Melee|Dagger|1d4|Piercing|1:Fine suit of clothes --1 --
-!import-table-item --Occupations-Crawl --Wizard's apprentice:Melee|Dagger|1d4|Piercing|1:Black grimoire --1 --
-!import-table-item --Occupations-Crawl --Woodcutter:Melee|Handaxe|1d6|Slashing|1:Bundle of wood --2 --
-!import-table-item --Occupations-Crawl --Gnome gardener:Melee|Hand garden fork|1d4|Piercing|1:Bag of flower weeds, green thumbs --1 --
-!import-table-item --Occupations-Crawl --Gnome entertainer:Melee|Black wand||1d4|Blunt|1:Shiny black top hat, white gloves --1 --
-!import-table-item --Occupations-Crawl --Gnome stroller:Melee|Walking stick|1d4|Blunt|1:Pants with large pockets (holding small rocks, thread) --1 --
+!import-table-item --Occupations-Crawl --Alchemist:melee|Staff|1d4|1||:Flask of oil --1 --
+!import-table-item --Occupations-Crawl --Animal trainer:melee|Club|1d4|1||:Pony --1 --
+!import-table-item --Occupations-Crawl --Armorer:melee|Hammer|1d4|1||:Iron helmet --1 --
+!import-table-item --Occupations-Crawl --Astrologer:both|Dagger|1d4|1|10/20/30|Thrown:Spyglass --1 --
+!import-table-item --Occupations-Crawl --Barber:both|Razor|1d4|1|10/20/30|Thrown:Scissors --1 --
+!import-table-item --Occupations-Crawl --Beadle:melee|Staff|1d4|1||:Holy symbol --1 --
+!import-table-item --Occupations-Crawl --Beekeeper:melee|Staff|1d4|1||:Jar of honey --1 --
+!import-table-item --Occupations-Crawl --Blacksmith:melee|Hammer|1d4|1||:Steel tongs --1 --
+!import-table-item --Occupations-Crawl --Butcher:both|Cleaver|1d6|1|10/20/30|Thrown:Side of beef --1 --
+!import-table-item --Occupations-Crawl --Caravan guard:melee|Short sword|1d6|1||:Linen (1 yard) --1 --
+!import-table-item --Occupations-Crawl --Cheesemaker:melee|Cudgel|1d4|1||:Stinky cheese --1 --
+!import-table-item --Occupations-Crawl --Cobbler:both|Awl|1d4|1|10/20/30|Thrown:Shoehorn --1 --
+!import-table-item --Occupations-Crawl --Confidence artist:both|Dagger|1d4|1|10/20/30|Thrown:Quality cloak --1 --
+!import-table-item --Occupations-Crawl --Cooper:melee|Crowbar|1d4|1||:Barrel --1 --
+!import-table-item --Occupations-Crawl --Costermonger:both|Knife|1d4|1|10/20/30|Thrown:Fruit --1 --
+!import-table-item --Occupations-Crawl --Cutpurse:both|Dagger|1d4|1|10/20/30|Thrown:Small chest --1 --
+!import-table-item --Occupations-Crawl --Ditch digger:melee|Shovel|1d4|1||:Fine dirt (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Dock worker:melee|Pole|1d4|1||:1 late RPG book --1 --
+!import-table-item --Occupations-Crawl --Dwarven apothecarist:melee|Cudgel|1d4|1||:Steel vial --1 --
+!import-table-item --Occupations-Crawl --Dwarven blacksmith:melee|Hammer|1d4|1||:Mithril (1 oz.) --1 --
+!import-table-item --Occupations-Crawl --Dwarven chest-maker:both|Chisel|1d4|1|10/20/30|Thrown:Wood (10 lbs.) --1 --
+!import-table-item --Occupations-Crawl --Dwarven herder:melee|Staff|1d4|1||:Sow --1 --
+!import-table-item --Occupations-Crawl --Dwarven miner:melee|Pick|1d4|1||:Lantern --2 --
+!import-table-item --Occupations-Crawl --Dwarven mushroom-farmer:melee|Shovel|1d4|1||:Sack --1 --
+!import-table-item --Occupations-Crawl --Dwarven rat-catcher:melee|Club|1d4|1||:Net --1 --
+!import-table-item --Occupations-Crawl --Dwarven stonemason:melee|Hammer|1d4|1||:Fine stone (10 lbs.) --2 --
+!import-table-item --Occupations-Crawl --Elven artisan:melee|Staff|1d4|1||:Clay (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Elven barrister:ranged|Quill|1d4|1|20/40/60|Thrown:Book --1 --
+!import-table-item --Occupations-Crawl --Elven chandler:both|Scissors|1d4|1|10/20/30|Thrown:Candles (20) --1 --
+!import-table-item --Occupations-Crawl --Elven falconer:both|Dagger|1d4|1|10/20/30|Thrown:Falcon --1 --
+!import-table-item --Occupations-Crawl --Elven forester:melee|Staff|1d4|1||:Herbs (1 lb.) --2 --
+!import-table-item --Occupations-Crawl --Elven glassblower:melee|Hammer|1d4|1||:Glass beads --1 --
+!import-table-item --Occupations-Crawl --Elven navigator:ranged|Shortbow|1d6|2|50/100/150|Normal:Spyglass --1 --
+!import-table-item --Occupations-Crawl --Elven sage:both|Dagger|1d4|1|10/20/30|Thrown:Parchment, quill --2 --
+!import-table-item --Occupations-Crawl --Farmer:melee|Pitchfork|1d8|1||:Hen --9 --
+!import-table-item --Occupations-Crawl --Fortune-teller:both|Dagger|1d4|1|10/20/30|Thrown:Tarot deck --1 --
+!import-table-item --Occupations-Crawl --Gambler:melee|Club|1d4|1||:Dice --1 --
+!import-table-item --Occupations-Crawl --Gongfarmer:both|Trowel|1d4|1|10/20/30|Thrown:Sack of night soil --1 --
+!import-table-item --Occupations-Crawl --Grave digger:melee|Shovel|1d4|1||:Trowel --2 --
+!import-table-item --Occupations-Crawl --Guild beggar:ranged|Sling|1d4|1|40/80/160|Thrown:Crutches --2 --
+!import-table-item --Occupations-Crawl --Halfling chicken butcher:both|Handaxe|1d6|1|10/20/30|Thrown:Chicken meat (5 lbs.) --1 --
+!import-table-item --Occupations-Crawl --Halfling dyer:melee|Staff|1d4|1||:Fabric (3 yards) --2 --
+!import-table-item --Occupations-Crawl --Halfling glovemaker:both|Awl|1d4|1|10/20/30|Thrown:Gloves (4 pairs) --1 --
+!import-table-item --Occupations-Crawl --Halfling gypsy:ranged|Sling|1d4|1|40/80/160|Thrown:Hex doll --1 --
+!import-table-item --Occupations-Crawl --Halfling haberdasher:both|Scissors|1d4|1|10/20/30|Thrown:Fine suits (3 sets) --1 --
+!import-table-item --Occupations-Crawl --Halfling mariner:both|Knife|1d4|1|10/20/30|Thrown:Sailcloth (2 yards) --1 --
+!import-table-item --Occupations-Crawl --Halfling moneylender:melee|Short sword|1d6|1||:5 gp, 10 sp, 200 cp --1 --
+!import-table-item --Occupations-Crawl --Halfling trader:melee|Short sword|1d6|1||:20 sp --1 --
+!import-table-item --Occupations-Crawl --Halfling vagrant:melee|Club|1d4|1||:Begging bowl --1 --
+!import-table-item --Occupations-Crawl --Healer:melee|Club|1d4|1||:Vial of holy water --1 --
+!import-table-item --Occupations-Crawl --Herbalist:melee|Club|1d4|1||:Herbs (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Herder:melee|Staff|1d4|1||:Herding dog --1 --
+!import-table-item --Occupations-Crawl --Hunter:ranged|Shortbow|1d6|2|50/100/150|Normal:Deer pelt --2 --
+!import-table-item --Occupations-Crawl --Indentured servant:melee|Staff|1d4|1||:Locket --1 --
+!import-table-item --Occupations-Crawl --Jester:ranged|Dart|1d4|1|20/40/60|Thrown:Silk clothes --1 --
+!import-table-item --Occupations-Crawl --Jeweler:both|Dagger|1d4|1|10/20/30|Thrown:Gem worth 20 gp --1 --
+!import-table-item --Occupations-Crawl --Locksmith:both|Dagger|1d4|1|10/20/30|Thrown:Fine tools --1 --
+!import-table-item --Occupations-Crawl --Mendicant:melee|Club|1d4|1||:Cheese dip --1 --
+!import-table-item --Occupations-Crawl --Mercenary:melee|Longsword|1d8|1||:Hide armor (+3 AC, -3 Check, d12 Fumble) --1 --
+!import-table-item --Occupations-Crawl --Merchant:both|Dagger|1d4|1|10/20/30|Thrown:4gp, 14 sp, 27 cp --1 --
+!import-table-item --Occupations-Crawl --Miller/baker:melee|Club|1d4|1||:Flour (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Minstrel:both|Dagger|1d4|1|10/20/30|Thrown:Ukulele --1 --
+!import-table-item --Occupations-Crawl --Noble:melee|Longsword|1d8|1||:Gold ring worth 10 gp --1 --
+!import-table-item --Occupations-Crawl --Orphan:melee|Club|1d4|1||:Rag doll --1 --
+!import-table-item --Occupations-Crawl --Ostler:melee|Staff|1d4|1||:Bridle --1 --
+!import-table-item --Occupations-Crawl --Outlaw:melee|Short sword|1d6|1||:Leather armor (AC +2, -1 Check, d8 Fumble) --1 --
+!import-table-item --Occupations-Crawl --Rope maker:both|Knife|1d4|1|10/20/30|Thrown:Rope (100') --1 --
+!import-table-item --Occupations-Crawl --Scribe:ranged|Dart|1d4|1|20/40/60|Thrown:Parchment (10 sheets) --1 --
+!import-table-item --Occupations-Crawl --Shaman:melee|Mace|1d6|1||:Herbs (1 lb.) --1 --
+!import-table-item --Occupations-Crawl --Slave:melee|Club|1d4|1||:Strange-looking rock --1 --
+!import-table-item --Occupations-Crawl --Smuggler:ranged|Sling|1d4|1|40/80/160|Thrown:Waterproof sack --1 --
+!import-table-item --Occupations-Crawl --Soldier:melee|Spear|1d8|1||:Shield (AC +1, Check -1) --1 --
+!import-table-item --Occupations-Crawl --Squire:melee|Longsword|1d8|1||:Steel helmet --2 --
+!import-table-item --Occupations-Crawl --Tax collector:melee|Longsword|1d8|1||:100 cp --1 --
+!import-table-item --Occupations-Crawl --Trapper:ranged|Sling|1d4|1|40/80/160|Thrown:Badger pelt --2 --
+!import-table-item --Occupations-Crawl --Urchin:melee|Stick|1d4|1||:Begging bowl --1 --
+!import-table-item --Occupations-Crawl --Wainwright:melee|Club|1d4|1||:Pushcart --1 --
+!import-table-item --Occupations-Crawl --Weaver:both|Dagger|1d4|1|10/20/30|Thrown:Fine suit of clothes --1 --
+!import-table-item --Occupations-Crawl --Wizard's apprentice:both|Dagger|1d4|1|10/20/30|Thrown:Black grimoire --1 --
+!import-table-item --Occupations-Crawl --Woodcutter:both|Handaxe|1d6|1|10/20/30|Thrown:Bundle of wood --3 --
+!import-table-item --Occupations-Crawl --Gnome gardener:both|Hand garden fork|1d4|1|10/20/30|Thrown:Bag of flower weeds, green thumbs --1 --
+!import-table-item --Occupations-Crawl --Gnome entertainer:melee|Black wand|1d4|1||:Shiny black top hat, white gloves --1 --
+!import-table-item --Occupations-Crawl --Gnome stroller:melee|Walking stick|1d4|1||:Pants with large pockets (holding small rocks, thread) --1 --

--- a/tables/individual/Occupations-Crawl.txt
+++ b/tables/individual/Occupations-Crawl.txt
@@ -20,7 +20,7 @@
 !import-table-item --Occupations-Crawl --Dwarven apothecarist:melee|Cudgel|1d4|1||:Steel vial --1 --
 !import-table-item --Occupations-Crawl --Dwarven blacksmith:melee|Hammer|1d4|1||:Mithril (1 oz.) --1 --
 !import-table-item --Occupations-Crawl --Dwarven chest-maker:both|Chisel|1d4|1|10/20/30|Thrown:Wood (10 lbs.) --1 --
-!import-table-item --Occupations-Crawl --Dwarven herder:melee|Staff|1d4|1||:Sow --1 --
+!import-table-item --Occupations-Crawl --Dwarven herder:melee|Staff|1d4|1||:$subtable-Farm-Animals-Core --1 --
 !import-table-item --Occupations-Crawl --Dwarven miner:melee|Pick|1d4|1||:Lantern --2 --
 !import-table-item --Occupations-Crawl --Dwarven mushroom-farmer:melee|Shovel|1d4|1||:Sack --1 --
 !import-table-item --Occupations-Crawl --Dwarven rat-catcher:melee|Club|1d4|1||:Net --1 --
@@ -33,7 +33,7 @@
 !import-table-item --Occupations-Crawl --Elven glassblower:melee|Hammer|1d4|1||:Glass beads --1 --
 !import-table-item --Occupations-Crawl --Elven navigator:ranged|Shortbow|1d6|2|50/100/150|Normal:Spyglass --1 --
 !import-table-item --Occupations-Crawl --Elven sage:both|Dagger|1d4|1|10/20/30|Thrown:Parchment, quill --2 --
-!import-table-item --Occupations-Crawl --Farmer:melee|Pitchfork|1d8|1||:Hen --9 --
+!import-table-item --Occupations-Crawl --$subtable-Farmer-Core:melee|Pitchfork|1d8|1||:$subtable-Farm-Animals-Core --9 --
 !import-table-item --Occupations-Crawl --Fortune-teller:both|Dagger|1d4|1|10/20/30|Thrown:Tarot deck --1 --
 !import-table-item --Occupations-Crawl --Gambler:melee|Club|1d4|1||:Dice --1 --
 !import-table-item --Occupations-Crawl --Gongfarmer:both|Trowel|1d4|1|10/20/30|Thrown:Sack of night soil --1 --
@@ -50,7 +50,7 @@
 !import-table-item --Occupations-Crawl --Halfling vagrant:melee|Club|1d4|1||:Begging bowl --1 --
 !import-table-item --Occupations-Crawl --Healer:melee|Club|1d4|1||:Vial of holy water --1 --
 !import-table-item --Occupations-Crawl --Herbalist:melee|Club|1d4|1||:Herbs (1 lb.) --1 --
-!import-table-item --Occupations-Crawl --Herder:melee|Staff|1d4|1||:Herding dog --1 --
+!import-table-item --Occupations-Crawl --Herder:melee|Staff|1d4|1||:$subtable-Farm-Animals-Core --1 --
 !import-table-item --Occupations-Crawl --Hunter:ranged|Shortbow|1d6|2|50/100/150|Normal:Deer pelt --2 --
 !import-table-item --Occupations-Crawl --Indentured servant:melee|Staff|1d4|1||:Locket --1 --
 !import-table-item --Occupations-Crawl --Jester:ranged|Dart|1d4|1|20/40/60|Thrown:Silk clothes --1 --
@@ -75,7 +75,7 @@
 !import-table-item --Occupations-Crawl --Tax collector:melee|Longsword|1d8|1||:100 cp --1 --
 !import-table-item --Occupations-Crawl --Trapper:ranged|Sling|1d4|1|40/80/160|Thrown:Badger pelt --2 --
 !import-table-item --Occupations-Crawl --Urchin:melee|Stick|1d4|1||:Begging bowl --1 --
-!import-table-item --Occupations-Crawl --Wainwright:melee|Club|1d4|1||:Pushcart --1 --
+!import-table-item --Occupations-Crawl --Wainwright:melee|Club|1d4|1||:$subtable-Pushcart-Core --1 --
 !import-table-item --Occupations-Crawl --Weaver:both|Dagger|1d4|1|10/20/30|Thrown:Fine suit of clothes --1 --
 !import-table-item --Occupations-Crawl --Wizard's apprentice:both|Dagger|1d4|1|10/20/30|Thrown:Black grimoire --1 --
 !import-table-item --Occupations-Crawl --Woodcutter:both|Handaxe|1d6|1|10/20/30|Thrown:Bundle of wood --3 --

--- a/tables/individual/Pushcart-Core.txt
+++ b/tables/individual/Pushcart-Core.txt
@@ -1,0 +1,7 @@
+!import-table --Pushcart-Core --show
+!import-table-item --Pushcart-Core --Pushcart full of tomatoes --1 --
+!import-table-item --Pushcart-Core --Empty pushcart --1 --
+!import-table-item --Pushcart-Core --Pushcart full of straw --1 --
+!import-table-item --Pushcart-Core --Pushcart full of your dead --1 --
+!import-table-item --Pushcart-Core --Pushcart full of dirt --1 --
+!import-table-item --Pushcart-Core --Pushcart full of rocks --1 --


### PR DESCRIPTION
I recently added Fodderator to my game recently which uses the DCC-Tabbed-Sheet and found that it didn't work. These are the fixes I made which kind of snowballed (I found editing the table text files manually really mentally exhausting, so I put the data in YAML files and added a generator to build the tables themselves).

Here's what it adds:

* data now stores in YAML tables (for easy editing and cross-referencing)
* fixed attribute assignment to work with DCC-Tabbed-Sheet (this may break things for people who don't use that sheet)
* generates the repeating row for the DCC-Tabbed-Sheet
* added support for weapons that are both ranged and melee
* sets the appropriate birth augur attribute (when applicable)
* removed damage type (piercing/blunt/slashing) - as far as i can tell neither character sheets make use of it

I'm not sure this is something you want to merge or not, depends on if you're still using Fodderator and how. But feel free to let me know if you have any feedback!